### PR TITLE
fix: harden import map generation and module resolution

### DIFF
--- a/.changeset/huge-pets-fly.md
+++ b/.changeset/huge-pets-fly.md
@@ -1,0 +1,17 @@
+---
+"vite-import-maps": patch
+---
+
+fix: harden import map generation and module resolution
+
+- preserve ESM default exports when generating production wrappers
+- safely serialize raw import maps exposed by the virtual module
+- resolve relative local entries from the configured Vite root
+- handle normalized dependency-name collisions with incremental suffixes
+- reject duplicate public import-map specifiers
+- fall back to uncached resolution when the dev optimizer is unavailable
+- emit a single warning when the optimizer fallback is active
+- add regression coverage across Vite 6, 7, and 8
+- document Node.js requirements and expand the README
+- add a roadmap for the remaining audit tasks
+- correct the package.json module field

--- a/README.md
+++ b/README.md
@@ -1,388 +1,444 @@
 <h1 align="center">vite-import-maps</h1>
-<br/>
+
 <p align="center">
-  <a href="https://npmjs.com/package/vite-import-maps"><img src="https://img.shields.io/npm/v/vite-import-maps.svg" alt="npm package"></a>
-  <a href="https://github.com/riccardoperra/vite-import-maps/actions/workflows/ci.yml"><img src="https://github.com/riccardoperra/vite-import-maps/actions/workflows/release.yml/badge.svg?branch=main" alt="build status"></a>
+  Generate browser import maps from the modules Vite resolves in development and emits in production.
 </p>
 
-A Vite plugin that generates and keeps *
-*browser [import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap)** in
-sync with your Vite dev server and production build.
+<p align="center">
+  <a href="https://npmjs.com/package/vite-import-maps"><img src="https://img.shields.io/npm/v/vite-import-maps.svg" alt="npm package version"></a>
+  <a href="https://npmjs.com/package/vite-import-maps"><img src="https://img.shields.io/npm/dm/vite-import-maps.svg" alt="npm monthly downloads"></a>
+  <a href="https://github.com/riccardoperra/vite-import-maps/actions/workflows/release.yml"><img src="https://github.com/riccardoperra/vite-import-maps/actions/workflows/release.yml/badge.svg?branch=main" alt="release workflow status"></a>
+</p>
 
-It's aimed at **micro-frontends**, **plugin systems**, and any setup where you load ESM modules at runtime and want to:
+`vite-import-maps` keeps a browser [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) aligned with Vite's module resolution. Declare packages or local entry points once; the plugin resolves them through the dev server and emits dedicated chunks during a production build.
 
-- Share dependencies (React, Solid, etc.) **without relying on CDNs**
-- Avoid bundling multiple copies of the same library
-- Expose npm packages or **your own local entry modules** through an import map
-- Keep **remote modules truly "native"**: remotes can be plain ESM files **without requiring you** to setup build step
-  or use other plugins.
+It is designed for micro-frontends, plugin systems, and applications that load ESM modules at runtime while hosting shared dependencies themselves.
 
----
+- Works in Vite development and production builds
+- Maps package specifiers and local ESM wrapper modules
+- Injects the map into HTML, exposes it as a virtual module, or emits JSON
+- Optionally adds integrity metadata to production chunks
+- Runs integration tests against Vite 6, 7, and 8
 
-## Table of Contents
+## Table of contents
 
 - [Install](#install)
-- [Setup](#setup)
+- [Quick start](#quick-start)
+- [Do you need this plugin?](#do-you-need-this-plugin)
 - [Configuration](#configuration)
-- [Do You Need This Plugin?](#do-you-need-this-plugin)
-- [CommonJS Compatibility](#commonjs-compatibility)
-- [Recipes](#recipes)
+- [Consume the import map](#consume-the-import-map)
+- [Remote builds](#remote-builds)
+- [CommonJS compatibility](#commonjs-compatibility)
+- [Browser compatibility](#browser-compatibility-and-es-module-shims)
+- [How it works](#how-it-works)
 - [Troubleshooting](#troubleshooting)
-- [How It Works](#how-it-works)
 - [Examples](#examples)
+- [Development](#development)
 - [License](#license)
-
----
 
 ## Install
 
-```shell
-# pnpm
-pnpm i -D vite-import-maps
+### Requirements
 
-# npm
-npm i -D vite-import-maps
+- Vite 6 or newer
+- A Node.js version that provides [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options):
+  - Node.js 20.12.0 or newer on the 20.x release line
+  - Node.js 21.7.0 or newer on the 21.x release line
+  - Node.js 22 or newer
 
-# yarn
-yarn add -D vite-import-maps
+```sh
+pnpm add -D vite-import-maps
 ```
 
-## Setup
+```sh
+npm install --save-dev vite-import-maps
+```
+
+```sh
+yarn add --dev vite-import-maps
+```
+
+## Quick start
+
+Add the plugin to the host application—the application that serves the import map and shared modules:
+
+Package entries such as `clsx` and `react` must already be installed in the host project.
 
 ```ts
-import {defineConfig} from "vite";
-import {viteImportMaps} from "vite-import-maps";
+import { defineConfig } from "vite";
+import { viteImportMaps } from "vite-import-maps";
 
-// Host app configuration
 export default defineConfig({
-    plugins: [
-        viteImportMaps({
-            // Add SRI hashes to verify module integrity in build
-            integrity: 'sha-384',
-            log: true,
-            imports: [
-                // Wanna expose react with import maps?
-                "react",
-                "react-dom",
-                // Expose a custom/local entry under a public specifier
-                {name: "react/jsx-runtime", entry: "./src/custom-jsx-runtime.ts"},
-                {name: "my-app-shared-lib", entry: "./src/my-app-shared-oib.ts"},
-            ],
-        }),
-    ],
+  plugins: [
+    viteImportMaps({
+      imports: [
+        // Expose installed dependencies under their package specifiers.
+        "clsx",
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+
+        // Expose a local module under a public specifier.
+        { name: "my-shared-lib", entry: "./src/my-shared-lib.ts" },
+      ],
+    }),
+  ],
 });
 ```
 
----
-
-## Configuration
-
-### Options
-
-- `imports` — List of modules to expose via the import map. Each entry can be a string (the specifier to expose, e.g.
-  `"react"`) or an object with `name` (the specifier), `entry` (the local path or package to resolve), and optionally
-  `integrity` (enable SRI hash).
-
-- `modulesOutDir` — Directory prefix for emitted shared chunks in production. Defaults to `""` (root of output
-  directory).
-
-- `integrity` —
-  Enable [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap#integrity_metadata_map)
-  for all shared dependencies. Set to `true`, `"sha256"`, `"sha384"`, or `"sha512"`. This adds an `integrity` map to the
-  import map so browsers can verify module contents. Can also be configured per-dependency via the object form in
-  `imports`.
-
-- `log` — Enable debug logging. Defaults to `false`.
-
-- `injectImportMapsToHtml` — Automatically inject a `<script type="importmap">` into the HTML `<head>`. Defaults to
-  `true`. Set to `false` for SSR apps and use the `virtual:importmap` module instead.
-
-- `importMapHtmlTransformer` — A function to transform the resolved `imports` object before injecting into HTML. Useful
-  for adding a base path prefix, rewriting URLs to a CDN, or filtering entries.
-
-- `outputAsFile` — Emit the import map as a standalone JSON file. Set to `true` for `/import-map.json`, or provide a
-  custom name (e.g. `"my-map"` → `/my-map.json`). The file is served by Vite in dev and emitted as an asset in build.
-
----
-
-## Do You Need This Plugin?
-
-If you're considering [import maps](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap),
-you're likely building one of the following:
-
-- **Micro-frontend architecture** — A host app loads remote modules at runtime, and all parts need to share the same
-  dependency instances (React, Solid, etc.)
-- **Plugin system** — Your app dynamically loads user-provided or third-party modules that rely on shared libraries
-- **Self-hosted dependency sharing** — You want to share dependencies across apps without relying on external CDN
-  services like esm.sh or jspm.io
-
-### Why Not Third-Party Services?
-
-Services like [esm.sh](https://esm.sh) or [jspm.io](https://jspm.io) are convenient, but they come with trade-offs:
-
-- **External dependency** — Your app relies on a third-party service you don't control. If it goes down or changes, your
-  app breaks.
-- **Network restrictions** — Many corporate environments, VPNs, and air-gapped networks block connections to public
-  services. Your app simply won't work.
-- **Version alignment** — Ensuring host and remotes use the exact same dependency version from an external source can be
-  error-prone.
-- **Limited flexibility** — You can't easily expose modified builds, subsets of exports, or local wrapper modules.
-
-With this plugin, **your host app becomes the source of truth**. Shared dependencies are built and served from your own
-infrastructure.
-
-### Why This Plugin?
-
-**Works in both development and production**
-
-Most import map solutions only work at build time. This plugin keeps the import map in sync with Vite's dev server _and_
-production builds. During development, it resolves to Vite's optimized deps; in production, it points to the correct
-hashed chunk filenames. No manual updates, no mismatches.
-
-**No build step required for remotes**
-
-Remote modules can be plain ESM files—no bundler, no plugins, no special conventions. They just `import "your-lib"` and
-the browser resolves it via the import map provided by the host.
-
-**Single dependency instance**
-
-Host and all remotes share the exact same module instances.
-
-**Full control over what you share**
-
-Expose npm packages as-is, or provide custom wrapper modules, modified builds, or local files. You decide exactly what
-each specifier resolves to.
-
-> **Note:** If a remote _does_ use a bundler, shared dependencies must be marked as **external**.
-> Otherwise the remote bundles its own copy and you lose the single-instance benefit.
-
-Import maps are simple in concept, but keeping them in sync with your build is tedious:
-
-- In dev, Vite serves optimized deps from `node_modules/.vite/deps` with cache-busting hashes
-- In production, chunks have content hashes in their filenames
-- Manually updating the import map every time something changes is error-prone
-
-This plugin handles all of that. You declare what to share, and it generates the correct import map for both dev and
-build—automatically.
-
-**Example output:**
+By default, the plugin prepends an import map to the generated HTML. A simplified production map looks like this:
 
 ```html
-
 <script type="importmap">
-    {
-      "imports": {
-        "react": "/shared/react-DyndEn3u.js",
-        "react/jsx-runtime": "/shared/react_jsx-runtime-CAvv468t.js"
-      }
+  {
+    "imports": {
+      "clsx": "./clsx.js",
+      "react": "./react.js",
+      "react-dom": "./react-dom.js",
+      "react/jsx-runtime": "./react_jsx-runtime.js",
+      "my-shared-lib": "./my-shared-lib.js"
     }
+  }
 </script>
 ```
 
----
-
-## CommonJS Compatibility
-
-Import maps work best with browser-compatible ESM modules. CommonJS packages may appear to work in some setups, but they
-can still introduce inconsistencies because the compatibility layer is usually provided by the bundler, not by the
-browser import map itself.
-
-This library includes a minimal compatibility layer for CommonJS modules: it tries to inspect their exports with
-`cjs-module-lexer` and generate an automatic wrapper when possible. However, depending on how a package is authored or
-bundled, that heuristic may not always be able to reproduce the expected browser behavior.
-
-For that reason, when you need to share a CommonJS dependency, it is still recommended to create a small local ESM
-wrapper that re-exports only what you need. This keeps the interop fully delegated to the bundler during the build step
-and tends to be more predictable than mapping the CommonJS entry directly.
-Reference: [Expose Local Entry Points](#expose-local-entry-points-custom-esm-wrappers)
-
-In general, prefer libraries that provide first-class ESM support whenever possible.
-
----
-
-## Recipes
-
-### Expose Local Entry Points (Custom ESM Wrappers)
-
-Expose a local file that re-exports a dependency, giving you full control over what gets shared:
+Production filenames follow your Vite output configuration, so they may include hashes.
 
 > [!NOTE]
-> See [CommonJS Compatibility](#commonjs-compatibility) for the general compatibility notes.
->
-> The React examples in [`examples/react-host-custom/src/react-esm.ts`](./examples/react-host-custom/src/react-esm.ts)
-> and [`examples/react-host-custom/src/react-jsx-runtime.ts`](./examples/react-host-custom/src/react-jsx-runtime.ts)
-> follow this pattern.
+> React, `clsx`, and other npm packages may resolve to CommonJS entry points. The plugin provides a compatibility wrapper when it can detect their exports. For explicit control, expose a local ESM wrapper such as [`react-esm.ts`](./examples/react-host-custom/src/react-esm.ts). See [CommonJS compatibility](#commonjs-compatibility).
+
+> [!IMPORTANT]
+> If a separately built remote imports one of these specifiers, configure that dependency as external in the remote build. Otherwise the remote will bundle its own copy and the import map will not provide a shared instance.
+
+## Do you need this plugin?
+
+This plugin is a good fit when the browser loads ESM modules at runtime and more than one part of your application needs to resolve the same bare import specifiers.
+
+Typical use cases include:
+
+- **Micro-frontends** — A host and independently delivered remotes need to resolve shared dependencies such as React, Vue, or Solid.
+- **Plugin systems** — Runtime-loaded plugins import APIs or libraries provided by the host application.
+- **Self-hosted dependency sharing** — You want the host to build and serve shared modules instead of loading them from a public CDN.
+- **Custom public entry points** — You want an import-map specifier to resolve to a local wrapper, a curated set of exports, or an application-owned module.
+
+The plugin is most valuable when you want to use browser import maps without manually keeping development URLs and production chunk filenames in sync. The host becomes the source of truth: it resolves each configured entry with Vite, then exposes the resulting map to the browser.
+
+### You may not need it when
+
+- Your application does not load modules at runtime.
+- Every dependency can stay inside one conventional application bundle.
+- A CDN-generated import map already meets your deployment and versioning requirements.
+- You need a complete micro-frontend runtime with remote discovery, version negotiation, fallbacks, or deployment orchestration. This plugin generates and exposes import maps; it does not provide those higher-level features.
+
+### Why self-host shared modules?
+
+Public services such as [esm.sh](https://esm.sh) and [JSPM](https://jspm.org) are convenient and may be the simplest option for some applications. Self-hosting is useful when you need tighter control over:
+
+- **Availability** — Shared modules are deployed with infrastructure you operate.
+- **Network policy** — The application does not depend on access to a public module CDN.
+- **Version alignment** — The host build determines the exact dependency versions it exposes.
+- **Customization** — Local ESM wrappers can adapt exports or provide application-specific entry points.
+
+Remote modules do not need a Vite plugin to consume the generated map. They can be plain browser ESM.
+
+## Configuration
+
+| Option                     | Default  | Description                                                                                                                                           |
+| -------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `imports`                  | required | Package specifiers or `{ name, entry }` mappings to expose. `name` is the public specifier; `entry` is the package or local file Vite resolves.       |
+| `modulesOutDir`            | `""`     | Directory prefix for emitted shared chunks, relative to Vite's build output.                                                                          |
+| `integrity`                | `false`  | Adds an integrity metadata map in production. `true` uses `sha384`; a hash name selects the algorithm.                                                |
+| `log`                      | `false`  | Enables detailed dependency-resolution logging.                                                                                                       |
+| `injectImportMapsToHtml`   | `true`   | Injects `<script type="importmap">` through Vite's `transformIndexHtml` hook. Disable it when another layer owns the HTML, including most SSR setups. |
+| `importMapHtmlTransformer` | identity | Transforms the complete resolved import-map object. It can rewrite URLs or add fields such as `scopes`.                                               |
+| `outputAsFile`             | `false`  | `true` serves/emits `import-map.json`; a string changes the basename, for example `"runtime-map"` produces `runtime-map.json`.                        |
+
+### Package entries
+
+A string uses the same value as the public specifier and the module Vite resolves:
 
 ```ts
 viteImportMaps({
-    imports: [
-        {name: "react", entry: "./src/react-esm.ts"},
-        {name: "react/jsx-runtime", entry: "./src/react-jsx-runtime.ts"},
-        "react-dom",
-    ],
-    modulesOutDir: "shared",
+  imports: ["react", "react-dom", "react/jsx-runtime"],
 });
 ```
 
----
-
-### Enable Integrity Checks
-
-Add SRI hashes to verify module integrity:
+Use the object form when the public specifier and resolved entry differ:
 
 ```ts
 viteImportMaps({
-    imports: ["react", "react-dom"],
-    integrity: "sha384", // applies to all
-});
-
-// Or per-dependency:
-viteImportMaps({
-    imports: [
-        {name: "react", entry: "react", integrity: "sha384"},
-        {name: "react-dom", entry: "react-dom", integrity: false},
-    ],
+  imports: [
+    { name: "react", entry: "./src/react-esm.ts" },
+    { name: "react/jsx-runtime", entry: "./src/react-jsx-runtime.ts" },
+  ],
 });
 ```
 
----
+Local entries are useful for exposing a controlled subset of exports or wrapping a CommonJS dependency in ESM.
 
-### Mark Shared Deps as `external` in Remote Builds
+### Integrity metadata
 
-If a remote module uses a bundler, configure shared dependencies as `external` to prevent bundling them:
-
-**tsdown example:**
+Set one default for every entry, then override individual dependencies when needed:
 
 ```ts
-import {defineConfig} from "tsdown";
+viteImportMaps({
+  integrity: "sha384",
+  imports: [
+    "react",
+    { name: "react-dom", entry: "react-dom", integrity: "sha512" },
+    { name: "my-shared-lib", entry: "./src/shared.ts", integrity: false },
+  ],
+});
+```
+
+Integrity hashes are calculated from emitted production chunks. Development import maps do not include integrity metadata.
+
+### Transform the generated map
+
+The transformer receives the full import map plus the registered entries and internal store:
+
+```ts
+viteImportMaps({
+  imports: ["react"],
+  importMapHtmlTransformer(importMap) {
+    return {
+      ...importMap,
+      imports: Object.fromEntries(
+        Object.entries(importMap.imports ?? {}).map(([name, url]) => [
+          name,
+          `/assets${url.slice(1)}`,
+        ]),
+      ),
+    };
+  },
+});
+```
+
+The transformed result is shared by HTML injection, the virtual module, and JSON-file output.
+
+## Consume the import map
+
+An [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script/type/importmap) tells the browser how to resolve a bare module specifier such as `clsx`. Consumers continue to write standard JavaScript imports; they do not call a plugin-specific runtime API.
+
+For example, a remote module can import `clsx` by package name:
+
+```js
+// public/remote-widget.js
+import clsx from "clsx";
+
+export function mount(target, { active = false } = {}) {
+  const button = document.createElement("button");
+  button.className = clsx("remote-widget", active && "is-active");
+  button.textContent = "Remote widget";
+  target.append(button);
+}
+```
+
+The host loads that remote by URL:
+
+```ts
+// src/main.ts
+const { mount } = await import("/remote-widget.js");
+
+mount(document.querySelector("#app")!, { active: true });
+```
+
+At runtime, the browser follows this sequence:
+
+1. The host HTML provides the generated import map.
+2. The host imports `/remote-widget.js` by URL.
+3. The remote evaluates `import clsx from "clsx"`.
+4. The browser resolves `clsx` to the URL recorded in the import map.
+
+The import map must appear before any module script that uses its specifiers. The default HTML integration handles that ordering by prepending the generated `<script type="importmap">` to the document head.
+
+### HTML injection
+
+HTML injection is enabled by default. It is the simplest option for a client-rendered Vite host with an `index.html` entry—no additional runtime setup is required.
+
+For a minimal repository example, compare the [basic fixture](./integration/test/fixture/basic) with its generated [Vite 8 HTML snapshot](./integration/test/__snapshot__/build-project-with-right-import-maps/vite8/index.html). The snapshot shows the import map injected ahead of the rest of the page content.
+
+### Virtual module
+
+The `virtual:importmap` module is always available and exports the parsed map, its JSON string, and the parsed map as the default export:
+
+```ts
+import importMap, { importMapRaw } from "virtual:importmap";
+```
+
+This is useful when an SSR framework owns the HTML document:
+
+```ts
+viteImportMaps({
+  imports: ["react"],
+  injectImportMapsToHtml: false,
+});
+```
+
+Render `importMapRaw` inside a `<script type="importmap">` element before any module that depends on mapped specifiers.
+
+If TypeScript cannot resolve the virtual module, add an ambient declaration in your application:
+
+```ts
+declare module "virtual:importmap" {
+  const importMap: {
+    imports?: Record<string, string>;
+    integrity?: Record<string, string>;
+    scopes?: Record<string, Record<string, string>>;
+  };
+
+  export const importMapRaw: string;
+  export { importMap };
+  export default importMap;
+}
+```
+
+### JSON file
+
+```ts
+viteImportMaps({
+  imports: ["react"],
+  outputAsFile: true,
+});
+```
+
+This serves `/import-map.json` in development and emits `import-map.json` at the root of the production bundle.
+
+## Remote builds
+
+Remote modules can be plain browser ESM. If a remote is bundled, externalize every specifier the host import map owns.
+
+### Vite library mode
+
+```ts
+import { defineConfig } from "vite";
 
 export default defineConfig({
-    external: ["react", "react-dom", "react/jsx-runtime"],
-});
-```
-
-**Vite (library mode) example:**
-
-```ts
-import {defineConfig} from "vite";
-
-export default defineConfig({
-    build: {
-        lib: {
-            entry: "./src/index.ts",
-            formats: ["es"],
-        },
-        rolldownOptions: {
-            external: ["react", "react-dom", "react/jsx-runtime"],
-        },
+  build: {
+    lib: {
+      entry: "./src/index.ts",
+      formats: ["es"],
     },
+    rolldownOptions: {
+      external: ["react", "react-dom", "react/jsx-runtime"],
+    },
+  },
 });
 ```
 
----
+For Vite versions that use Rollup configuration, place the same `external` array under `build.rollupOptions`.
 
-### Serve Import Map as JSON File
+### tsdown
+
+```ts
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  external: ["react", "react-dom", "react/jsx-runtime"],
+});
+```
+
+## CommonJS compatibility
+
+Browser import maps resolve ESM specifiers; they do not convert CommonJS for the browser. During production builds, this plugin uses `cjs-module-lexer` to detect named exports and generate a small compatibility wrapper when possible.
+
+That detection is necessarily heuristic. For predictable behavior, prefer packages with first-class ESM builds or expose a local ESM wrapper:
+
+```ts
+// src/legacy-lib-esm.ts
+import legacyLib from "legacy-lib";
+
+export const parse = legacyLib.parse;
+export default legacyLib;
+```
 
 ```ts
 viteImportMaps({
-    imports: ["react"],
-    outputAsFile: true, // /import-map.json
+  imports: [{ name: "legacy-lib", entry: "./src/legacy-lib-esm.ts" }],
 });
 ```
 
----
+See the [React host with custom ESM wrappers](./examples/react-host-custom) for a complete example.
+
+## Browser compatibility and es-module-shims
+
+Use [es-module-shims](https://github.com/guybedford/es-module-shims) when your browser support policy or runtime workflow needs an import-map polyfill. The map can be loaded dynamically from JSON:
+
+```ts
+import "es-module-shims";
+
+const importMap = await fetch("/import-map.json").then((response) =>
+  response.json(),
+);
+
+await importShim.addImportMap(importMap);
+await importShim.import("/src/main.ts");
+```
+
+See the [React es-module-shims example](./examples/react-host-es-module-shims).
+
+## How it works
+
+### Development
+
+1. Vite resolves every configured entry through its plugin container.
+2. The plugin converts resolved files into dev-server URLs.
+3. The current map is exposed through HTML, `virtual:importmap`, and optionally JSON.
+
+### Production
+
+1. The plugin creates a dedicated build input for each configured entry.
+2. Vite/Rollup emits those inputs as shared chunks.
+3. The plugin records final filenames and optional integrity hashes.
+4. The completed map is injected or emitted with the rest of the bundle.
+
+The production integration suite exercises this flow across Vite 6, 7, and 8. See the [fixtures](./integration/test/fixture) and [build snapshots](./integration/test/__snapshot__).
 
 ## Troubleshooting
 
-### SSR App Doesn't Show the Import Map
+### A dependency is bundled into a remote
 
-Set `injectImportMapsToHtml: false` and inject the import map yourself using `virtual:importmap`:
+Add its exact import specifier to the remote build's `external` configuration. Externalizing `react` does not automatically externalize `react/jsx-runtime`.
 
-```ts
-import importMap from "virtual:importmap";
-// Inject into your SSR HTML template
-```
+### A specifier resolves to the wrong module
 
----
+Import-map keys are exact unless you intentionally create a trailing-slash prefix mapping. Configure every subpath your code imports, such as `react/jsx-runtime` or `solid-js/web`.
 
-### Specifier Resolves to the Wrong Module
+### An SSR page has no import map
 
-Ensure the specifier matches exactly what your code imports:
+Set `injectImportMapsToHtml: false`, import `virtual:importmap` in the server-rendering path, and render the script before dependent module scripts.
 
-- `react/jsx-runtime` ≠ `react`
-- `solid-js/web` ≠ `solid-js`
+### A CommonJS package behaves differently between dev and build
 
----
+Expose a local ESM wrapper and re-export only the API the remote consumes. This lets Vite own the CommonJS interop instead of relying on static export detection.
 
-### Import Maps Not Supported in Target Browser
+### A local entry cannot be resolved
 
-Import maps require modern browsers. For broader support, use a polyfill
-like [es-module-shims](https://github.com/guybedford/es-module-shims).
-
-See the example: [`./examples/react-host-es-module-shims`](./examples/react-host-es-module-shims)
-
-### Integrate with es-module-shims (dynamic import maps)
-
-You can integrate this plugin with **es-module-shims** in two common ways depending on how you want import maps applied
-at runtime:
-
-- **Apply import maps dynamically at runtime** — If you prefer the plugin to emit a JSON file (use `outputAsFile: true`)
-  or to use the `virtual:importmap` module, you can fetch or import the map and pass it to the es-module-shims runtime
-  via the global `importShim` API (it exposes helpers like `addImportMap` and `import`).
-
-  ```ts
-  import "es-module-shims";
-
-  // When using outputAsFile: true (e.g. /import-map.json)
-  fetch("/import-map.json")
-    .then((r) => r.json())
-    .then((map) => importShim.addImportMap(map))
-    .then(() => importShim.import("/your/entry.js"));
-  ```
-
-  Example (virtual module):
-
-  ```js
-  import "es-module-shims";
-  import importMap from "virtual:importmap";
-
-  importShim.addImportMap(importMap).then(() => {
-    // now safe to dynamically import shimmed modules
-  });
-  ```
-
----
-
-## How It Works
-
-1. **Collects** the `shared` entries from your config
-2. **In dev:** Resolves corresponding Vite dev-server URLs
-3. **In build:** Adds extra Rollup inputs so shared deps get dedicated output chunks, then records the final chunk URLs
-4. **Exposes** the mapping via:
-    - HTML injection (optional)
-    - `virtual:importmap` module (always)
-    - JSON file (optional)
-
-**Build snapshot:**
-
-- [`./test/fixture/basic`](./test/fixture/basic)
-- [`./test/__snapshot__/build-project-with-right-import-maps`](./test/__snapshot__/build-project-with-right-import-maps)
-
----
+Use a path relative to the Vite process working directory or an absolute path. If your Vite `root` differs from that directory, an absolute path is the least ambiguous choice.
 
 ## Examples
 
-| Example                                                               | Description                              |
-|-----------------------------------------------------------------------|------------------------------------------|
-| [`solidjs-host`](./examples/solidjs-host)                             | Solid.js host app                        |
-| [`solidjs-remote-counter`](./examples/solidjs-remote-counter)         | Solid.js remote module                   |
-| [`react-host-custom`](./examples/react-host-custom)                   | React host with custom ESM wrappers      |
-| [`react-host-es-module-shims`](./examples/react-host-es-module-shims) | React host with es-module-shims polyfill |
-| [`react-remote-counter`](./examples/react-remote-counter)             | React remote module                      |
-| [`react-tanstack-start-ssr`](./examples/react-tanstack-start-ssr)     | SSR example with TanStack Start          |
+| Example                                                                  | Purpose                                                                     |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| [React host with custom wrappers](./examples/react-host-custom)          | Host-side React mappings with local ESM entry points and integrity metadata |
+| [React host with es-module-shims](./examples/react-host-es-module-shims) | JSON output and dynamic import-map application                              |
+| [React remote counter](./examples/react-remote-counter)                  | Vite library-mode remote with shared imports externalized                   |
+| [React + TanStack Start SSR](./examples/react-tanstack-start-ssr)        | Manual import-map injection in an SSR application                           |
+| [Solid host](./examples/solidjs-host)                                    | Solid host application and multiple package subpaths                        |
+| [Solid remote counter](./examples/solidjs-remote-counter)                | Solid remote with shared dependencies externalized                          |
+| [Vue host](./examples/vue-host-app)                                      | Vue host application                                                        |
+| [Vue remote counter](./examples/vue-remote-counter)                      | Vue library-mode remote                                                     |
 
----
+## Development
+
+```sh
+pnpm install
+pnpm build
+pnpm test
+```
+
+The test command runs production-build integration fixtures against Vite 6, 7, and 8.
 
 ## License
 
-MIT. See [LICENSE](./LICENSE).
+[MIT](./LICENSE)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,268 @@
+# Project roadmap
+
+This roadmap turns the repository audit into trackable engineering work. It focuses on correctness first, then compatibility, test coverage, and package quality.
+
+Last updated: 2026-07-11
+
+## Status legend
+
+| Status         | Meaning                                                           |
+| -------------- | ----------------------------------------------------------------- |
+| ✅ Done        | Implemented and verified against its acceptance criteria          |
+| 🔵 In review   | Implementation exists and is awaiting final verification or merge |
+| 🟡 In progress | Work has started but is not ready for review                      |
+| ⬜ Planned     | Scoped but not started                                            |
+| ⛔ Blocked     | Cannot proceed until the documented blocker is resolved           |
+
+## Current overview
+
+| ID         | Priority | Status         | Work item                                               |
+| ---------- | -------- | -------------- | ------------------------------------------------------- |
+| DOC-001    | P1       | 🔵 In review   | Refactor and expand the README                          |
+| PKG-001    | P2       | 🟡 In progress | Correct the `module` package field                      |
+| CORE-001   | P0       | 🔵 In review   | Preserve ESM default exports in production wrappers     |
+| CORE-002   | P0       | 🔵 In review   | Serialize `virtual:importmap` output safely             |
+| RES-001    | P1       | 🔵 In review   | Resolve local entries from the Vite root                |
+| RES-002    | P1       | 🔵 In review   | Prevent normalized dependency-name collisions           |
+| DEV-001    | P1       | 🔵 In review   | Support dev environments without a dependency optimizer |
+| COMPAT-001 | P1       | 🟡 In progress | Define and enforce the supported Node.js range          |
+| TOOL-001   | P1       | ⬜ Planned     | Restore direct TypeScript validation                    |
+| API-001    | P2       | ⬜ Planned     | Export the public configuration types                   |
+| PKG-002    | P2       | ⬜ Planned     | Review peer dependency requirements                     |
+| TEST-001   | P1       | 🟡 In progress | Add development-server integration coverage             |
+| TEST-002   | P1       | 🟡 In progress | Cover all import-map output mechanisms                  |
+| TEST-003   | P1       | ⬜ Planned     | Complete CommonJS coverage across Vite versions         |
+| TEST-004   | P2       | 🟡 In progress | Add resolution and collision regression fixtures        |
+
+## Phase 1 — Correctness and runtime safety
+
+### CORE-001 — Preserve ESM default exports in production wrappers
+
+- **Priority:** P0
+- **Status:** 🔵 In review
+- **Decision:** Export `default` only when the resolved ESM module declares it.
+- **Current state:** Implemented and covered by the basic fixture across Vite 6, 7, and 8.
+- **Area:** [`src/build-only/virtual-chunk-resolver.ts`](./src/build-only/virtual-chunk-resolver.ts)
+- **Problem:** Production wrappers use `export * from "dependency"`, which does not re-export the dependency's default export. A dependency can therefore work in development but lose its default export after a production build.
+- **Implementation notes:**
+  - Determine whether the resolved ESM module exposes a default export.
+  - Generate a default re-export only when it is valid.
+  - Preserve named exports and side effects.
+  - Avoid changing the existing CommonJS wrapper behavior unintentionally.
+- **Acceptance criteria:**
+  - A fixture with both default and named ESM exports works in development and production.
+  - The default export is present in builds produced with Vite 6, 7, and 8.
+  - Existing build snapshots and CommonJS fixtures continue to pass.
+
+### CORE-002 — Serialize `virtual:importmap` output safely
+
+- **Priority:** P0
+- **Status:** 🔵 In review
+- **Decision:** Accepted for implementation.
+- **Current state:** Implemented with regression coverage for quotes, newlines, and Unicode separators.
+- **Area:** [`src/import-map-module.ts`](./src/import-map-module.ts)
+- **Problem:** `importMapRaw` is embedded inside a generated single-quoted JavaScript string. An apostrophe or another string-sensitive character introduced by a transformer can generate invalid module code.
+- **Implementation notes:**
+  - Serialize the raw JSON string as a JavaScript string literal instead of interpolating it directly.
+  - Keep the named and default parsed-map exports unchanged.
+- **Acceptance criteria:**
+  - Maps containing apostrophes, quotes, newlines, and Unicode separators load successfully.
+  - `importMapRaw`, `importMap`, and the default export contain equivalent data.
+  - A regression test imports the generated virtual module rather than checking only its source text.
+
+## Phase 2 — Resolution and environment compatibility
+
+### RES-001 — Resolve local entries from the Vite root
+
+- **Priority:** P1
+- **Status:** 🔵 In review
+- **Decision:** Accepted for implementation.
+- **Current state:** Implemented with a custom-root local-entry fixture across Vite 6, 7, and 8. Windows CI verification remains pending.
+- **Area:** [`src/build-only/virtual-chunk-generator.ts`](./src/build-only/virtual-chunk-generator.ts)
+- **Problem:** Relative local entries are resolved from `process.cwd()` instead of Vite's resolved `root`. This is ambiguous in monorepos and projects with a custom root.
+- **Implementation notes:**
+  - Capture the resolved Vite configuration or use Vite's resolver for local entries.
+  - Preserve absolute-path and Windows-path support.
+- **Acceptance criteria:**
+  - A fixture with `root` different from `process.cwd()` resolves a relative local entry correctly.
+  - Absolute local entries continue to work on all CI operating systems.
+  - README guidance can describe paths relative to the Vite root.
+
+### RES-002 — Prevent normalized dependency-name collisions
+
+- **Priority:** P1
+- **Status:** 🔵 In review
+- **Decision:** Preserve readable names when unique and append an incremental suffix only when a collision occurs.
+- **Current state:** Implemented with coverage for readable names, incremental collision suffixes, and duplicate public specifiers.
+- **Area:** [`src/utils.ts`](./src/utils.ts), [`src/store.ts`](./src/store.ts)
+- **Problem:** Replacing `/` with `_` means different specifiers such as `foo/bar` and `foo_bar` normalize to the same virtual ID and output name.
+- **Implementation notes:**
+  - Keep the current readable normalized name when it is unique.
+  - When that name is occupied, append the first available incremental suffix: `foo_bar`, `foo_bar_1`, `foo_bar_2`.
+  - Detect duplicate public names and duplicate generated IDs early.
+  - Return an actionable configuration error instead of silently overwriting an entry.
+- **Acceptance criteria:**
+  - Previously colliding specifiers produce distinct chunks and import-map entries.
+  - Exact duplicate public specifiers fail with a clear error.
+  - Scoped packages and package subpaths retain readable output names.
+
+### DEV-001 — Support dev environments without a dependency optimizer
+
+- **Priority:** P1
+- **Status:** 🔵 In review
+- **Feasibility:** Confirmed. The optimizer currently supplies only the browser-hash cache key; module resolution already goes through Vite's plugin container.
+- **Decision:** Resolve on every HTML transformation when no browser hash is available and emit one warning per plugin instance.
+- **Current state:** Implemented with isolated hook coverage. A real dev-server integration test remains pending.
+- **Area:** [`src/dev/dev-plugin.ts`](./src/dev/dev-plugin.ts)
+- **Problem:** The development plugin assumes `clientEnvironment.depsOptimizer` always exists. Disabled optimization or a different environment configuration can cause a runtime exception.
+- **Implementation notes:**
+  - Treat the optimizer and its metadata as optional.
+  - Fall back to resolving configured entries on each HTML transformation when the browser hash is unavailable.
+  - Clear stale store entries when the resolved dependency set changes.
+- **Acceptance criteria:**
+  - Development works with dependency optimization enabled and disabled.
+  - A missing optimizer does not throw.
+  - Cache invalidation updates the generated map when resolved URLs change.
+
+### COMPAT-001 — Define and enforce the supported Node.js range
+
+- **Priority:** P1
+- **Status:** 🟡 In progress
+- **Area:** [`package.json`](./package.json), CI workflows, uses of `node:util` `styleText`
+- **Problem:** Runtime code uses Node APIs that are unavailable in some Node versions supported by Vite 6, while the package does not declare a Node.js engine requirement.
+- **Decision:** Keep `styleText`. Document Node.js 20.12.0+, 21.7.0+, and 22+ as the supported minimums for their respective release lines.
+- **Current state:** The Node.js requirement is documented in the README. Package metadata and CI enforcement remain pending.
+- **Implementation notes:**
+  - Add an equivalent range to `package.json#engines`, for example `>=20.12.0 <21 || >=21.7.0`.
+  - Test the minimum and current supported Node versions in CI.
+- **Acceptance criteria:**
+  - Installing on an unsupported Node version produces a clear package-manager warning.
+  - Build and tests pass on the minimum declared Node version.
+  - The documented Vite and Node compatibility ranges agree.
+
+## Phase 3 — Tooling, API, and package quality
+
+### TOOL-001 — Restore direct TypeScript validation
+
+- **Priority:** P1
+- **Status:** ⬜ Planned
+- **Area:** [`tsconfig.json`](./tsconfig.json), [`package.json`](./package.json)
+- **Problem:** `tsc -p tsconfig.json` fails because `isolatedDeclarations` is enabled without `declaration` or `composite`.
+- **Implementation notes:**
+  - Separate type-checking and declaration-build configurations if necessary.
+  - Add a dedicated `typecheck` script.
+  - Run it in pull-request and release CI.
+- **Acceptance criteria:**
+  - `pnpm typecheck` succeeds from a clean checkout.
+  - CI fails on source type errors independently of the package bundler.
+  - Declaration generation through `tsdown` still succeeds.
+
+### API-001 — Export the public configuration types
+
+- **Priority:** P2
+- **Status:** ⬜ Planned
+- **Area:** [`src/index.ts`](./src/index.ts), [`src/config.ts`](./src/config.ts)
+- **Problem:** Configuration and import-map types appear in generated declarations but cannot be imported from the package entry point.
+- **Implementation notes:**
+  - Export only the types intended as stable public API.
+  - Consider exporting `VitePluginImportMapsConfig`, `SharedDependencyConfig`, `SharedDependencyObjectConfig`, `ImportMapSignature`, and `ImportMapTransformerFn`.
+- **Acceptance criteria:**
+  - A consumer type test can import every documented public type from `vite-import-maps`.
+  - Internal store and build metadata types remain private.
+  - The README uses exported names where appropriate.
+
+### PKG-001 — Correct the `module` package field
+
+- **Priority:** P2
+- **Status:** 🟡 In progress
+- **Area:** [`package.json`](./package.json)
+- **Current state:** The working tree already changes `"module "` to `"module"`.
+- **Acceptance criteria:**
+  - `publint` passes.
+  - The package dry run contains the expected ESM entry point and declaration file.
+  - The correction is included in the next release changeset if required by the release policy.
+
+### PKG-002 — Review peer dependency requirements
+
+- **Priority:** P2
+- **Status:** ⬜ Planned
+- **Area:** [`package.json`](./package.json)
+- **Problem:** Vite, Rollup, and Rolldown are all optional peers even though the distributed package imports Vite at runtime. This can hide missing or unnecessary requirements from consumers.
+- **Implementation notes:**
+  - Make Vite a required peer unless a supported non-Vite use case is documented and tested.
+  - Determine whether direct Rollup and Rolldown peers are necessary.
+  - Verify installation behavior with npm, pnpm, and Yarn.
+- **Acceptance criteria:**
+  - A clean consumer installation receives correct peer dependency guidance.
+  - No redundant build-engine peer is required from application users.
+  - `publint` and package-manager installation fixtures pass.
+
+## Phase 4 — Test coverage and regression protection
+
+### TEST-001 — Add development-server integration coverage
+
+- **Priority:** P1
+- **Status:** 🟡 In progress
+- **Current state:** Isolated plugin coverage exists for the missing-optimizer fallback and warning behavior. End-to-end server coverage remains pending.
+- **Covers:** development resolution, optimizer presence/absence, caching, HTML injection, and dev JSON output.
+- **Acceptance criteria:**
+  - Tests start a Vite dev server and request generated HTML and JSON.
+  - Tests verify resolved URLs rather than only checking HTTP status.
+  - At least one local entry and one installed package are covered.
+
+### TEST-002 — Cover every import-map output mechanism
+
+- **Priority:** P1
+- **Status:** 🟡 In progress
+- **Current state:** The virtual module now has executable regression coverage. HTML, JSON, transformer consistency, and SSR coverage remain pending.
+- **Covers:** HTML injection, `virtual:importmap`, `outputAsFile`, transformers, SSR/manual injection, and output consistency.
+- **Acceptance criteria:**
+  - All three output mechanisms return the same transformed map.
+  - Custom JSON basenames are tested in development and production.
+  - SSR builds do not emit or resolve unintended client-only chunks.
+
+### TEST-003 — Complete CommonJS coverage across Vite versions
+
+- **Priority:** P1
+- **Status:** ⬜ Planned
+- **Area:** [`integration/test/build.test.ts`](./integration/test/build.test.ts)
+- **Problem:** Default-export CommonJS coverage is currently skipped on Vite 6 and 7.
+- **Acceptance criteria:**
+  - The expected support policy for CommonJS default and named exports is explicit.
+  - Supported behavior is tested on Vite 6, 7, and 8.
+  - Unsupported cases produce documented limitations or actionable errors.
+
+### TEST-004 — Add resolution and collision regression fixtures
+
+- **Priority:** P2
+- **Status:** 🟡 In progress
+- **Current state:** Custom-root resolution, normalized-name collisions, and duplicate public names are covered. Windows paths, scoped packages, and full duplicate-input build coverage remain pending.
+- **Covers:** custom Vite roots, absolute entries, Windows paths, scoped packages, subpaths, duplicate inputs, and normalized-name collisions.
+- **Acceptance criteria:**
+  - Each resolution edge case has a focused fixture and assertion.
+  - Fixtures run across the supported Vite matrix where behavior differs.
+  - Snapshot output remains deterministic across operating systems.
+
+## Documentation
+
+### DOC-001 — Refactor and expand the README
+
+- **Priority:** P1
+- **Status:** 🔵 In review
+- **Area:** [`README.md`](./README.md)
+- **Current state:** The working tree contains the revised positioning, quick start, configuration reference, consumption walkthrough, SSR guidance, CommonJS notes, examples, and troubleshooting content.
+- **Acceptance criteria:**
+  - All local links resolve.
+  - README formatting and package dry run pass.
+  - Technical claims remain aligned with implemented and tested behavior.
+  - The final copy is approved and merged.
+
+## Definition of done
+
+A roadmap item can move to **Done** only when:
+
+1. The implementation and regression tests are complete.
+2. `pnpm build`, `pnpm test`, linting, type-checking, and package validation pass where applicable.
+3. User-facing behavior and limitations are documented.
+4. Compatibility is verified across the affected Vite, Node.js, and operating-system matrix.
+5. A changeset is added when the change affects the published package.

--- a/integration/test/__snapshot__/build-project-with-integrity/vite6/@import-maps/shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-integrity/vite6/@import-maps/shared-lib.js
@@ -2,7 +2,12 @@ function foo() {
   return "test";
 }
 const bar = "bar";
+const sharedLib = {
+  foo,
+  bar
+};
 export {
   bar,
+  sharedLib as default,
   foo
 };

--- a/integration/test/__snapshot__/build-project-with-integrity/vite6/index.html
+++ b/integration/test/__snapshot__/build-project-with-integrity/vite6/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script type="importmap">{"imports":{"shared-lib":"./@import-maps/shared-lib.js"},"integrity":{"./@import-maps/shared-lib.js":"sha384-CLsEbj0RB39XLft9+2RZEesTwYhCrdQ8kb5K16nlO0WsjgBqnHXmIcm5KoW1Sjnf"}}</script>
+    <script type="importmap">{"imports":{"shared-lib":"./@import-maps/shared-lib.js"},"integrity":{"./@import-maps/shared-lib.js":"sha384-q8v71WwK0mk17gUrGpnCvQS7zqVnJfmWAY+H2tNiw2MBnqK/yfMiP/IFF09GiFMc"}}</script>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/integration/test/__snapshot__/build-project-with-integrity/vite7/@import-maps/shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-integrity/vite7/@import-maps/shared-lib.js
@@ -2,7 +2,12 @@ function foo() {
   return "test";
 }
 const bar = "bar";
+const sharedLib = {
+  foo,
+  bar
+};
 export {
   bar,
+  sharedLib as default,
   foo
 };

--- a/integration/test/__snapshot__/build-project-with-integrity/vite7/index.html
+++ b/integration/test/__snapshot__/build-project-with-integrity/vite7/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script type="importmap">{"imports":{"shared-lib":"./@import-maps/shared-lib.js"},"integrity":{"./@import-maps/shared-lib.js":"sha384-CLsEbj0RB39XLft9+2RZEesTwYhCrdQ8kb5K16nlO0WsjgBqnHXmIcm5KoW1Sjnf"}}</script>
+    <script type="importmap">{"imports":{"shared-lib":"./@import-maps/shared-lib.js"},"integrity":{"./@import-maps/shared-lib.js":"sha384-q8v71WwK0mk17gUrGpnCvQS7zqVnJfmWAY+H2tNiw2MBnqK/yfMiP/IFF09GiFMc"}}</script>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/integration/test/__snapshot__/build-project-with-integrity/vite8/@import-maps/shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-integrity/vite8/@import-maps/shared-lib.js
@@ -3,5 +3,9 @@ function foo() {
 	return "test";
 }
 var bar = "bar";
+var sharedLib = {
+	foo,
+	bar: "bar"
+};
 //#endregion
-export { bar, foo };
+export { bar, sharedLib as default, foo };

--- a/integration/test/__snapshot__/build-project-with-integrity/vite8/index.html
+++ b/integration/test/__snapshot__/build-project-with-integrity/vite8/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script type="importmap">{"imports":{"shared-lib":"./@import-maps/shared-lib.js"},"integrity":{"./@import-maps/shared-lib.js":"sha384-jdpnt4euCHcaTxg6xPozZT07z9nZHQwIMqDbrG1FztUa8G9NqxDuppLeOQn1sgKS"}}</script>
+    <script type="importmap">{"imports":{"shared-lib":"./@import-maps/shared-lib.js"},"integrity":{"./@import-maps/shared-lib.js":"sha384-42zmQq+x3fNEDjPUmFI5FqVrQJiIeIN+Qk/AB/brvqzZ7B6TUzOfTw0+56H4Drnn"}}</script>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite6/@import-maps/local-shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite6/@import-maps/local-shared-lib.js
@@ -1,0 +1,8 @@
+function foo() {
+  return "local";
+}
+const localSharedLib = { foo };
+export {
+  localSharedLib as default,
+  foo
+};

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite6/index.html
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite6/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js"}}</script>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Local entry</title>
+  </head>
+  <body></body>
+</html>

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite7/@import-maps/local-shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite7/@import-maps/local-shared-lib.js
@@ -1,0 +1,8 @@
+function foo() {
+  return "local";
+}
+const localSharedLib = { foo };
+export {
+  localSharedLib as default,
+  foo
+};

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite7/index.html
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite7/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js"}}</script>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Local entry</title>
+  </head>
+  <body></body>
+</html>

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite8/@import-maps/local-shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite8/@import-maps/local-shared-lib.js
@@ -1,0 +1,7 @@
+//#region test/fixture/local-entry/shared-lib.ts
+function foo() {
+	return "local";
+}
+var localSharedLib = { foo };
+//#endregion
+export { localSharedLib as default, foo };

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite8/index.html
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite8/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js"}}</script>
+
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Local entry</title>
+  </head>
+  <body></body>
+</html>

--- a/integration/test/__snapshot__/build-project-with-right-import-maps/vite6/@import-maps/shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-right-import-maps/vite6/@import-maps/shared-lib.js
@@ -2,7 +2,12 @@ function foo() {
   return "test";
 }
 const bar = "bar";
+const sharedLib = {
+  foo,
+  bar
+};
 export {
   bar,
+  sharedLib as default,
   foo
 };

--- a/integration/test/__snapshot__/build-project-with-right-import-maps/vite7/@import-maps/shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-right-import-maps/vite7/@import-maps/shared-lib.js
@@ -2,7 +2,12 @@ function foo() {
   return "test";
 }
 const bar = "bar";
+const sharedLib = {
+  foo,
+  bar
+};
 export {
   bar,
+  sharedLib as default,
   foo
 };

--- a/integration/test/__snapshot__/build-project-with-right-import-maps/vite8/@import-maps/shared-lib.js
+++ b/integration/test/__snapshot__/build-project-with-right-import-maps/vite8/@import-maps/shared-lib.js
@@ -3,5 +3,9 @@ function foo() {
 	return "test";
 }
 var bar = "bar";
+var sharedLib = {
+	foo,
+	bar: "bar"
+};
 //#endregion
-export { bar, foo };
+export { bar, sharedLib as default, foo };

--- a/integration/test/build.test.ts
+++ b/integration/test/build.test.ts
@@ -30,9 +30,36 @@ describe.each([
       fileName: "@import-maps/shared-lib.js",
     });
 
+    const builtChunk = await import(
+      pathToFileURL(path.join(buildOutput, sharedDependency.fileName)).href
+    );
+    expect(builtChunk.default.foo()).toEqual("test");
+    expect(builtChunk.bar).toEqual("bar");
+
     const expectedImportMap: ImportMap = {
       imports: {
         "shared-lib": `./${sharedDependency.fileName}`,
+      },
+    };
+
+    expectImportMapMatchesOutputs(result, expectedImportMap);
+  });
+
+  test("resolve local entries relative to the Vite root", async () => {
+    const { buildOutput, result } = await buildFixture(
+      "./fixture/local-entry/vite.config-test.js",
+      version,
+    );
+    const sharedDependency = await expectSharedChunk({
+      result,
+      buildOutput,
+      name: "@import-maps/local-shared-lib",
+      fileName: "@import-maps/local-shared-lib.js",
+    });
+
+    const expectedImportMap: ImportMap = {
+      imports: {
+        "local-shared-lib": `./${sharedDependency.fileName}`,
       },
     };
 

--- a/integration/test/fixture/basic/shared-lib.ts
+++ b/integration/test/fixture/basic/shared-lib.ts
@@ -4,7 +4,9 @@ export function foo() {
 
 export const bar = "bar";
 
-export default {
+const sharedLib = {
   foo,
   bar,
 };
+
+export default sharedLib;

--- a/integration/test/fixture/local-entry/index.html
+++ b/integration/test/fixture/local-entry/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Local entry</title>
+  </head>
+  <body></body>
+</html>

--- a/integration/test/fixture/local-entry/shared-lib.ts
+++ b/integration/test/fixture/local-entry/shared-lib.ts
@@ -1,0 +1,7 @@
+export function foo() {
+  return "local";
+}
+
+const localSharedLib = { foo };
+
+export default localSharedLib;

--- a/integration/test/fixture/local-entry/vite.config-test.ts
+++ b/integration/test/fixture/local-entry/vite.config-test.ts
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { viteImportMaps } from "vite-import-maps";
+import type { UserConfig } from "vite";
+
+const root = import.meta.dirname;
+const buildOutput = path.resolve(
+  import.meta.dirname,
+  "../../__snapshot__/build-project-with-local-entry",
+);
+
+export default {
+  root,
+  build: {
+    outDir: buildOutput,
+    minify: false,
+    rolldownOptions: {
+      input: {
+        index: path.resolve(root, "index.html"),
+      },
+      output: {
+        chunkFileNames: "[name].js",
+        entryFileNames: "[name].js",
+      },
+    },
+  },
+  plugins: [
+    viteImportMaps({
+      imports: [{ name: "local-shared-lib", entry: "./shared-lib.ts" }],
+      modulesOutDir: "@import-maps",
+    }),
+  ],
+} satisfies UserConfig;

--- a/integration/test/fixture/with-integrity/shared-lib.ts
+++ b/integration/test/fixture/with-integrity/shared-lib.ts
@@ -4,7 +4,9 @@ export function foo() {
 
 export const bar = "bar";
 
-export default {
+const sharedLib = {
   foo,
   bar,
 };
+
+export default sharedLib;

--- a/integration/test/plugin.test.ts
+++ b/integration/test/plugin.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test, vi } from "vitest";
+import { viteImportMaps } from "../../src/index.js";
+import type { Plugin } from "vite";
+
+function findPlugin(plugins: Array<Plugin>, name: string): Plugin {
+  const plugin = plugins.find((candidate) => candidate.name === name);
+  expect(plugin, `Expected plugin ${name}`).toBeDefined();
+  return plugin!;
+}
+
+async function loadVirtualImportMap(plugin: Plugin) {
+  if (typeof plugin.resolveId !== "function") {
+    throw new TypeError("Expected a resolveId hook");
+  }
+  if (typeof plugin.load !== "function") {
+    throw new TypeError("Expected a load hook");
+  }
+
+  // @ts-expect-error Direct hook invocation for isolated plugin testing.
+  const resolvedId = await plugin.resolveId.call({}, "virtual:importmap");
+  // @ts-expect-error Direct hook invocation for isolated plugin testing.
+  return plugin.load.call({}, resolvedId);
+}
+
+describe("virtual:importmap", () => {
+  test("safely serializes raw import maps", async () => {
+    const plugins = viteImportMaps({
+      imports: [],
+      importMapHtmlTransformer: () => ({
+        imports: {
+          quoted: "./it's-valid.js",
+          multiline: "./line\nbreak.js",
+          unicode: "./separator\u2028.js",
+        },
+      }),
+    });
+    const plugin = findPlugin(
+      plugins,
+      "vite-import-maps:virtual-module-import-map",
+    );
+    const code = await loadVirtualImportMap(plugin);
+
+    expect(typeof code).toBe("string");
+    const module = await import(
+      `data:text/javascript,${encodeURIComponent(String(code))}`
+    );
+
+    expect(module.default).toEqual({
+      imports: {
+        quoted: "./it's-valid.js",
+        multiline: "./line\nbreak.js",
+        unicode: "./separator\u2028.js",
+      },
+    });
+    expect(JSON.parse(module.importMapRaw)).toEqual(module.default);
+  });
+});
+
+describe("development import maps", () => {
+  test("falls back with a warning when the dependency optimizer is unavailable", async () => {
+    const plugins = viteImportMaps({ imports: ["shared-lib"] });
+    const developmentPlugin = findPlugin(
+      plugins,
+      "vite-import-maps:development",
+    );
+    const virtualModulePlugin = findPlugin(
+      plugins,
+      "vite-import-maps:virtual-module-import-map",
+    );
+    const resolveId = vi.fn(() => ({
+      id: "/project/node_modules/shared-lib/index.js",
+    }));
+    const warn = vi.fn();
+    const server = {
+      pluginContainer: { resolveId },
+      config: {
+        root: "/project",
+        logger: { warn },
+      },
+      environments: {
+        client: {},
+      },
+    };
+
+    if (typeof developmentPlugin.transformIndexHtml !== "function") {
+      throw new TypeError("Expected a transformIndexHtml hook");
+    }
+
+    for (let index = 0; index < 2; index++) {
+      // @ts-expect-error Minimal dev-server mock for isolated plugin testing.
+      await developmentPlugin.transformIndexHtml.call({}, "", { server });
+    }
+
+    expect(warn).toHaveBeenCalledOnce();
+    expect(resolveId).toHaveBeenCalledTimes(2);
+
+    const code = await loadVirtualImportMap(virtualModulePlugin);
+    const module = await import(
+      `data:text/javascript,${encodeURIComponent(String(code))}`
+    );
+    expect(module.default).toEqual({
+      imports: {
+        "shared-lib": "/node_modules/shared-lib/index.js",
+      },
+    });
+  });
+});
+
+describe("dependency identifiers", () => {
+  test("adds an incremental suffix only when normalized names collide", async () => {
+    const plugins = viteImportMaps({ imports: ["foo/bar", "foo_bar"] });
+    const resolver = findPlugin(
+      plugins,
+      "vite-import-maps:build:virtual-chunks-loader",
+    );
+
+    if (typeof resolver.resolveId !== "function") {
+      throw new TypeError("Expected a resolveId hook");
+    }
+
+    // @ts-expect-error Direct hook invocation for isolated plugin testing.
+    const first = await resolver.resolveId.call(
+      { environment: { name: "client" } },
+      "\0virtual:import-map-chunk/foo_bar",
+    );
+    // @ts-expect-error Direct hook invocation for isolated plugin testing.
+    const second = await resolver.resolveId.call(
+      { environment: { name: "client" } },
+      "\0virtual:import-map-chunk/foo_bar_1",
+    );
+
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+  });
+
+  test("rejects duplicate public specifiers", () => {
+    expect(() => viteImportMaps({ imports: ["react", "react"] })).toThrow(
+      "Duplicate import-map dependency: react",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.6",
   "description": "A Vite plugin that manages import maps for shared dependencies in your Vite applications.",
   "main": "./dist/index.mjs",
-  "module ": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "type": "module",
   "exports": {

--- a/src/build-only/virtual-chunk-generator.ts
+++ b/src/build-only/virtual-chunk-generator.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import * as path from "node:path/posix";
+import * as path from "node:path";
 import { styleText } from "node:util";
 import { createLogger } from "vite";
 import { pluginName } from "../config.js";
@@ -23,10 +23,14 @@ export function virtualChunksGeneratorPlugin(
   const logger = createLogger(undefined, {
     prefix: name,
   });
+  let root = process.cwd();
 
   return {
     name,
     apply: "build",
+    configResolved(config) {
+      root = config.root;
+    },
     buildStart() {
       logger.info("Emit chunks for exposed dependencies", { timestamp: true });
       for (const input of store.inputs) {
@@ -36,7 +40,7 @@ export function virtualChunksGeneratorPlugin(
           // need to be transformed
           const id = isAbsolute(input.idToResolve)
             ? normalizePath(input.idToResolve)
-            : normalizePath(path.normalize(path.resolve(input.idToResolve)));
+            : normalizePath(path.resolve(root, input.idToResolve));
           if (!localModules.has(id)) {
             if (store.log) {
               console.info(

--- a/src/build-only/virtual-chunk-resolver.ts
+++ b/src/build-only/virtual-chunk-resolver.ts
@@ -81,7 +81,12 @@ export function virtualChunksResolverPlugin(
         ("commonjs" in moduleInfo.meta &&
           moduleInfo.meta.commonjs.isCommonJS !== false);
 
-      let code = `export * from "${chunk.originalDependencyName}"`;
+      const dependencyName = JSON.stringify(chunk.originalDependencyName);
+      let code = `export * from ${dependencyName};`;
+
+      if (moduleInfo.exports.includes("default")) {
+        code += `\nexport { default } from ${dependencyName};`;
+      }
 
       if (isCjs) {
         const commonJsNamedExports =

--- a/src/dev/dev-plugin.ts
+++ b/src/dev/dev-plugin.ts
@@ -14,6 +14,7 @@ export function pluginImportMapsDevelopmentEnv(
   const name = pluginName("development");
   let latestBrowserHash: string | undefined = undefined;
   let cachedResolvedModules: Array<DevResolvedModule> = [];
+  let optimizerWarningLogged = false;
 
   return {
     name,
@@ -23,18 +24,26 @@ export function pluginImportMapsDevelopmentEnv(
     // Here we will not inject any import map script, but we will track the dependencies into the store
     async transformIndexHtml(_, { server }) {
       if (!server) return;
-      const loggingContext = store.log ? this : undefined;
       const { pluginContainer, config } = server,
         // This is just an improvement to avoid unnecessary calls to the pluginContainer
         // We get the depsOptimizer config to retrieve the latest browser hash.
         // Inside depsOptimizer we also have the dependencies with their own path,
         // but it's preferred to resolve those urls via pluginContainer.
         clientEnvironment = server.environments["client"],
-        devOptimizer = clientEnvironment.depsOptimizer!;
+        devOptimizer = clientEnvironment.depsOptimizer;
+
+      if (!devOptimizer && !optimizerWarningLogged) {
+        config.logger.warn(
+          `[${name}] Vite dependency optimizer is unavailable; import-map entries will be resolved on every HTML transformation.`,
+        );
+        optimizerWarningLogged = true;
+      }
+
+      const browserHash = devOptimizer?.metadata.browserHash;
 
       let resolvedModules: Array<DevResolvedModule>;
 
-      if (devOptimizer.metadata.browserHash === latestBrowserHash) {
+      if (browserHash && browserHash === latestBrowserHash) {
         resolvedModules = cachedResolvedModules;
       } else {
         resolvedModules = (
@@ -57,8 +66,9 @@ export function pluginImportMapsDevelopmentEnv(
       }
 
       cachedResolvedModules = resolvedModules;
-      latestBrowserHash = devOptimizer.metadata.browserHash;
+      latestBrowserHash = browserHash;
 
+      store.clearDependencies();
       for (const { path: url, name: packageName } of resolvedModules) {
         store.addDependency({ packageName, url });
       }

--- a/src/import-map-module.ts
+++ b/src/import-map-module.ts
@@ -2,11 +2,11 @@ import { pluginName } from "./config.js";
 import type { VitePluginImportMapsStore } from "./store.js";
 import type { Plugin } from "vite";
 
-const virtualImportMapId = 'virtual:importmap';
+const virtualImportMapId = "virtual:importmap";
 const resolvedVirtualImportMapId = "\0" + virtualImportMapId;
 
 export function pluginImportMapsAsModule(
-  store: VitePluginImportMapsStore
+  store: VitePluginImportMapsStore,
 ): Plugin {
   const name = pluginName("virtual-module-import-map");
 
@@ -21,7 +21,7 @@ export function pluginImportMapsAsModule(
       if (id === resolvedVirtualImportMapId) {
         const content = JSON.stringify(store.getImportMapAsJson());
         return `
-          export const importMapRaw = '${content}';
+          export const importMapRaw = ${JSON.stringify(content)};
           export const importMap = ${content};
           export default importMap;
         `;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,9 @@
 import * as path from "node:path/posix";
-import { isLocalEntry, normalizeDependencyName, normalizePath  } from "./utils.js";
+import {
+  isLocalEntry,
+  normalizeDependencyName,
+  normalizePath,
+} from "./utils.js";
 import type {
   DependencyIntegrityCheck,
   ImportMapSignature,
@@ -84,7 +88,26 @@ export class VitePluginImportMapsStore {
 
   addInput(input: NormalizedDependencyInput): ImportMapBuildChunkEntrypoint {
     const dependency = input.name;
-    const normalizedDepName = this.getNormalizedDependencyName(dependency);
+    if (
+      this.inputs.some(
+        (registered) => registered.originalDependencyName === dependency,
+      )
+    ) {
+      throw new Error(`Duplicate import-map dependency: ${dependency}`);
+    }
+
+    const normalizedName = this.getNormalizedDependencyName(dependency);
+    let normalizedDepName = normalizedName;
+    let suffix = 1;
+    while (
+      this.inputs.some(
+        (registered) =>
+          registered.normalizedDependencyName === normalizedDepName,
+      )
+    ) {
+      normalizedDepName = `${normalizedName}_${suffix++}`;
+    }
+
     const entrypoint = this.getEntrypointPath(normalizedDepName);
 
     const meta = {


### PR DESCRIPTION
- preserve ESM default exports when generating production wrappers
- safely serialize raw import maps exposed by the virtual module
- resolve relative local entries from the configured Vite root
- handle normalized dependency-name collisions with incremental suffixes
- reject duplicate public import-map specifiers
- fall back to uncached resolution when the dev optimizer is unavailable
- emit a single warning when the optimizer fallback is active
- add regression coverage across Vite 6, 7, and 8
- document Node.js requirements and expand the README
- add a roadmap for the remaining audit tasks
- correct the package.json module field