### PR TITLE
Compute integrity hashes after Vite dynamic-import rewrites

### DIFF
--- a/.changeset/shiny-streets-chew.md
+++ b/.changeset/shiny-streets-chew.md
@@ -1,0 +1,5 @@
+---
+"vite-import-maps": patch
+---
+
+fix: compute integrity hashes after Vite dynamic-import rewrites

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm run build
+
       - name: Publish PR review
         run: pnpm dlx pkg-pr-new publish

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite6/index.html
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite6/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js"}}</script>
+    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js","local-shared-lib-alias":"./@import-maps/local-shared-lib.js"}}</script>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite7/index.html
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite7/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js"}}</script>
+    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js","local-shared-lib-alias":"./@import-maps/local-shared-lib.js"}}</script>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/integration/test/__snapshot__/build-project-with-local-entry/vite8/index.html
+++ b/integration/test/__snapshot__/build-project-with-local-entry/vite8/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js"}}</script>
+    <script type="importmap">{"imports":{"local-shared-lib":"./@import-maps/local-shared-lib.js","local-shared-lib-alias":"./@import-maps/local-shared-lib.js"}}</script>
 
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/integration/test/build.test-utils.ts
+++ b/integration/test/build.test-utils.ts
@@ -14,6 +14,10 @@ interface BuiltFixture {
   result: RolldownOutput;
 }
 
+interface BuildFixtureOptions {
+  write?: boolean;
+}
+
 interface SharedChunkAssertionOptions {
   result: RolldownOutput;
   buildOutput: string;
@@ -91,6 +95,7 @@ const jiti = createJiti(import.meta.url, {
 export async function buildFixture(
   configPath: string,
   version: 6 | 7 | 8,
+  options: BuildFixtureOptions = {},
 ): Promise<BuiltFixture> {
   const configUrl = new URL(configPath, import.meta.url);
   // Load fixture config as a fresh module to avoid sharing plugin state
@@ -124,6 +129,7 @@ export async function buildFixture(
             rolldownOptions,
           }),
       outDir: versionedOutDir,
+      ...(options.write === undefined ? {} : { write: options.write }),
     },
   } satisfies UserConfig;
 

--- a/integration/test/build.test.ts
+++ b/integration/test/build.test.ts
@@ -49,7 +49,7 @@ describe.each([
     expectImportMapMatchesOutputs(result, expectedImportMap);
   });
 
-  test("resolve local entries relative to the Vite root", async () => {
+  test("preserve aliases that resolve to the same local entry", async () => {
     const { buildOutput, result } = await buildFixture(
       "./fixture/local-entry/vite.config-test.js",
       version,
@@ -64,6 +64,7 @@ describe.each([
     const expectedImportMap: ImportMap = {
       imports: {
         "local-shared-lib": `./${sharedDependency.fileName}`,
+        "local-shared-lib-alias": `./${sharedDependency.fileName}`,
       },
     };
 
@@ -105,17 +106,19 @@ describe.each([
       version,
     );
     const sharedDependency = findChunkByName(result, "@import-maps/shared-lib");
-    const htmlImportMap = parseImportMapFromHtml(
-      findAssetByFileName(result, "index.html"),
+    const htmlAsset = findAssetByFileName(result, "index.html");
+    const importMapAsset = findAssetByFileName(result, "import-map.json");
+    const htmlSource = await readFile(
+      path.join(buildOutput, htmlAsset.fileName),
+      "utf8",
     );
-    const fileImportMap = JSON.parse(
-      String(findAssetByFileName(result, "import-map.json").source),
-    ) as ImportMap;
-
-    expect(sharedDependency.code).toContain("__vite__mapDeps");
-    expect(fileImportMap).toEqual(htmlImportMap);
-
-    const sharedDependencyUrl = htmlImportMap.imports["shared-lib"];
+    const importMapSource = await readFile(
+      path.join(buildOutput, importMapAsset.fileName),
+      "utf8",
+    );
+    const htmlImportMap = parseImportMapFromHtml(htmlAsset);
+    const fileImportMap = JSON.parse(importMapSource) as ImportMap;
+    const sharedDependencyUrl = `./${sharedDependency.fileName}`;
     const emittedContents = await readFile(
       path.join(buildOutput, sharedDependencyUrl.slice(2)),
     );
@@ -124,9 +127,25 @@ describe.each([
       .update(emittedContents)
       .digest("base64")}`;
 
-    expect(htmlImportMap.integrity?.[sharedDependencyUrl]).toBe(
-      expectedIntegrity,
-    );
+    expect(String(htmlAsset.source)).toBe(htmlSource);
+    expect(String(importMapAsset.source)).toBe(importMapSource);
+    expect(htmlSource).not.toContain("__vite_import_maps_placeholder__");
+    expect(importMapSource).not.toContain("__vite_import_maps_placeholder__");
+    expect(htmlSource).not.toContain("data-vite-import-maps");
+    expect(importMapSource).not.toContain("data-vite-import-maps");
+    expect(htmlSource).not.toContain("vite-import-maps-");
+    expect(importMapSource).not.toContain("vite-import-maps-");
+    expect(String(emittedContents)).toContain("__vite__mapDeps");
+    expect(String(emittedContents)).not.toContain("__VITE_PRELOAD__");
+    expect(htmlImportMap).toEqual({
+      imports: {
+        "shared-lib": sharedDependencyUrl,
+      },
+      integrity: {
+        [sharedDependencyUrl]: expectedIntegrity,
+      },
+    });
+    expect(fileImportMap).toEqual(htmlImportMap);
   });
 
   test("GH-29 hashes final in-memory dynamic-import chunk contents", async () => {
@@ -136,25 +155,35 @@ describe.each([
       { write: false },
     );
     const sharedDependency = findChunkByName(result, "@import-maps/shared-lib");
-    const htmlImportMap = parseImportMapFromHtml(
-      findAssetByFileName(result, "index.html"),
-    );
-    const fileImportMap = JSON.parse(
-      String(findAssetByFileName(result, "import-map.json").source),
-    ) as ImportMap;
-    const sharedDependencyUrl = htmlImportMap.imports["shared-lib"];
+    const htmlAsset = findAssetByFileName(result, "index.html");
+    const importMapAsset = findAssetByFileName(result, "import-map.json");
+    const htmlSource = String(htmlAsset.source);
+    const importMapSource = String(importMapAsset.source);
+    const htmlImportMap = parseImportMapFromHtml(htmlAsset);
+    const fileImportMap = JSON.parse(importMapSource) as ImportMap;
+    const sharedDependencyUrl = `./${sharedDependency.fileName}`;
     const expectedIntegrity = `sha384-${crypto
       .createHash("sha384")
       .update(sharedDependency.code)
       .digest("base64")}`;
 
-    expect(sharedDependency.fileName).toBe(sharedDependencyUrl.slice(2));
+    expect(htmlSource).not.toContain("__vite_import_maps_placeholder__");
+    expect(importMapSource).not.toContain("__vite_import_maps_placeholder__");
+    expect(htmlSource).not.toContain("data-vite-import-maps");
+    expect(importMapSource).not.toContain("data-vite-import-maps");
+    expect(htmlSource).not.toContain("vite-import-maps-");
+    expect(importMapSource).not.toContain("vite-import-maps-");
     expect(sharedDependency.code).toContain("__vite__mapDeps");
     expect(sharedDependency.code).not.toContain("__VITE_PRELOAD__");
+    expect(htmlImportMap).toEqual({
+      imports: {
+        "shared-lib": sharedDependencyUrl,
+      },
+      integrity: {
+        [sharedDependencyUrl]: expectedIntegrity,
+      },
+    });
     expect(fileImportMap).toEqual(htmlImportMap);
-    expect(htmlImportMap.integrity?.[sharedDependencyUrl]).toBe(
-      expectedIntegrity,
-    );
   });
 
   test.skipIf(version < 8)(

--- a/integration/test/build.test.ts
+++ b/integration/test/build.test.ts
@@ -1,11 +1,15 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { readFile } from "node:fs/promises";
 import crypto from "node:crypto";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   buildFixture,
   expectImportMapMatchesOutputs,
   expectSharedChunk,
+  findAssetByFileName,
+  findChunkByName,
+  parseImportMapFromHtml,
 } from "./build.test-utils.js";
 import type { ImportMap } from "./build.test-utils.js";
 
@@ -92,6 +96,65 @@ describe.each([
     };
 
     expectImportMapMatchesOutputs(result, expectedImportMap);
+  });
+
+  // https://github.com/riccardoperra/vite-import-maps/issues/29
+  test("GH-29 hashes final dynamic-import chunk contents", async () => {
+    const { buildOutput, result } = await buildFixture(
+      "./fixture/gh-29-with-dynamic-import-integrity/vite.config-test.js",
+      version,
+    );
+    const sharedDependency = findChunkByName(result, "@import-maps/shared-lib");
+    const htmlImportMap = parseImportMapFromHtml(
+      findAssetByFileName(result, "index.html"),
+    );
+    const fileImportMap = JSON.parse(
+      String(findAssetByFileName(result, "import-map.json").source),
+    ) as ImportMap;
+
+    expect(sharedDependency.code).toContain("__vite__mapDeps");
+    expect(fileImportMap).toEqual(htmlImportMap);
+
+    const sharedDependencyUrl = htmlImportMap.imports["shared-lib"];
+    const emittedContents = await readFile(
+      path.join(buildOutput, sharedDependencyUrl.slice(2)),
+    );
+    const expectedIntegrity = `sha384-${crypto
+      .createHash("sha384")
+      .update(emittedContents)
+      .digest("base64")}`;
+
+    expect(htmlImportMap.integrity?.[sharedDependencyUrl]).toBe(
+      expectedIntegrity,
+    );
+  });
+
+  test("GH-29 hashes final in-memory dynamic-import chunk contents", async () => {
+    const { result } = await buildFixture(
+      "./fixture/gh-29-with-dynamic-import-integrity/vite.config-test.js",
+      version,
+      { write: false },
+    );
+    const sharedDependency = findChunkByName(result, "@import-maps/shared-lib");
+    const htmlImportMap = parseImportMapFromHtml(
+      findAssetByFileName(result, "index.html"),
+    );
+    const fileImportMap = JSON.parse(
+      String(findAssetByFileName(result, "import-map.json").source),
+    ) as ImportMap;
+    const sharedDependencyUrl = htmlImportMap.imports["shared-lib"];
+    const expectedIntegrity = `sha384-${crypto
+      .createHash("sha384")
+      .update(sharedDependency.code)
+      .digest("base64")}`;
+
+    expect(sharedDependency.fileName).toBe(sharedDependencyUrl.slice(2));
+    expect(sharedDependency.code).toContain("__vite__mapDeps");
+    expect(sharedDependency.code).not.toContain("__VITE_PRELOAD__");
+    expect(fileImportMap).toEqual(htmlImportMap);
+    expect(htmlImportMap.integrity?.[sharedDependencyUrl]).toBe(
+      expectedIntegrity,
+    );
   });
 
   test.skipIf(version < 8)(

--- a/integration/test/fixture/gh-29-with-dynamic-import-integrity/index.html
+++ b/integration/test/fixture/gh-29-with-dynamic-import-integrity/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GH-29 integrity after dynamic imports</title>
+  </head>
+  <body></body>
+</html>

--- a/integration/test/fixture/gh-29-with-dynamic-import-integrity/lazy.css
+++ b/integration/test/fixture/gh-29-with-dynamic-import-integrity/lazy.css
@@ -1,0 +1,3 @@
+.lazy {
+  color: rebeccapurple;
+}

--- a/integration/test/fixture/gh-29-with-dynamic-import-integrity/lazy.ts
+++ b/integration/test/fixture/gh-29-with-dynamic-import-integrity/lazy.ts
@@ -1,0 +1,3 @@
+import "./lazy.css";
+
+export const lazyValue = "lazy";

--- a/integration/test/fixture/gh-29-with-dynamic-import-integrity/shared-lib.ts
+++ b/integration/test/fixture/gh-29-with-dynamic-import-integrity/shared-lib.ts
@@ -1,0 +1,4 @@
+export async function loadLazyValue() {
+  const { lazyValue } = await import("./lazy.js");
+  return lazyValue;
+}

--- a/integration/test/fixture/gh-29-with-dynamic-import-integrity/vite.config-test.ts
+++ b/integration/test/fixture/gh-29-with-dynamic-import-integrity/vite.config-test.ts
@@ -36,5 +36,31 @@ export default {
       modulesOutDir: "@import-maps",
       outputAsFile: true,
     }),
+    {
+      name: "test:pretty-print-import-map",
+      apply: "build",
+      transformIndexHtml: {
+        order: "post",
+        handler(html) {
+          const match = html.match(
+            /(<script\b(?=[^>]*\btype\s*=\s*["']importmap["'])[^>]*>)([\s\S]*?)(<\/script>)/i,
+          );
+          if (!match) {
+            throw new Error("Expected an import map script to format");
+          }
+
+          const formattedImportMap = JSON.stringify(
+            JSON.parse(match[2]),
+            null,
+            2,
+          );
+
+          return html.replace(
+            match[0],
+            `${match[1]}\n${formattedImportMap}\n${match[3]}`,
+          );
+        },
+      },
+    },
   ],
 } satisfies UserConfig;

--- a/integration/test/fixture/gh-29-with-dynamic-import-integrity/vite.config-test.ts
+++ b/integration/test/fixture/gh-29-with-dynamic-import-integrity/vite.config-test.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import { viteImportMaps } from "vite-import-maps";
+import type { UserConfig } from "vite";
+
+const root = import.meta.dirname;
+const buildOutput = path.resolve(
+  import.meta.dirname,
+  "../../../dist/gh-29-with-dynamic-import-integrity",
+);
+
+export default {
+  root,
+  resolve: {
+    alias: {
+      "shared-lib": path.resolve(root, "shared-lib.ts"),
+    },
+  },
+  build: {
+    outDir: buildOutput,
+    minify: false,
+    rolldownOptions: {
+      input: {
+        index: path.resolve(root, "index.html"),
+      },
+      output: {
+        chunkFileNames: "[name].js",
+        entryFileNames: "[name].js",
+        assetFileNames: "assets/[name][extname]",
+      },
+    },
+  },
+  plugins: [
+    viteImportMaps({
+      integrity: "sha384",
+      imports: ["shared-lib"],
+      modulesOutDir: "@import-maps",
+      outputAsFile: true,
+    }),
+  ],
+} satisfies UserConfig;

--- a/integration/test/fixture/local-entry/vite.config-test.ts
+++ b/integration/test/fixture/local-entry/vite.config-test.ts
@@ -25,7 +25,10 @@ export default {
   },
   plugins: [
     viteImportMaps({
-      imports: [{ name: "local-shared-lib", entry: "./shared-lib.ts" }],
+      imports: [
+        { name: "local-shared-lib", entry: "./shared-lib.ts" },
+        { name: "local-shared-lib-alias", entry: "./shared-lib.ts" },
+      ],
       modulesOutDir: "@import-maps",
     }),
   ],

--- a/integration/test/plugin.test.ts
+++ b/integration/test/plugin.test.ts
@@ -58,10 +58,17 @@ describe("virtual:importmap", () => {
 
 describe("development import maps", () => {
   test("falls back with a warning when the dependency optimizer is unavailable", async () => {
-    const plugins = viteImportMaps({ imports: ["shared-lib"] });
+    const plugins = viteImportMaps({
+      imports: ["shared-lib"],
+      integrity: "sha384",
+    });
     const developmentPlugin = findPlugin(
       plugins,
       "vite-import-maps:development",
+    );
+    const htmlPlugin = findPlugin(
+      plugins,
+      "vite-import-maps:inject-html-import-map",
     );
     const virtualModulePlugin = findPlugin(
       plugins,
@@ -91,8 +98,29 @@ describe("development import maps", () => {
       await developmentPlugin.transformIndexHtml.call({}, "", { server });
     }
 
+    if (typeof htmlPlugin.transformIndexHtml !== "function") {
+      throw new TypeError("Expected a transformIndexHtml hook");
+    }
+
+    // @ts-expect-error Minimal dev-server mock for isolated plugin testing.
+    const transformedHtml = await htmlPlugin.transformIndexHtml.call({}, "", {
+      server,
+    });
+
     expect(warn).toHaveBeenCalledOnce();
     expect(resolveId).toHaveBeenCalledTimes(2);
+    expect(transformedHtml).toEqual({
+      html: "",
+      tags: [
+        {
+          tag: "script",
+          attrs: { type: "importmap" },
+          children:
+            '{"imports":{"shared-lib":"/node_modules/shared-lib/index.js"}}',
+          injectTo: "head-prepend",
+        },
+      ],
+    });
 
     const code = await loadVirtualImportMap(virtualModulePlugin);
     const module = await import(

--- a/src/build-only/build-plugin.ts
+++ b/src/build-only/build-plugin.ts
@@ -1,10 +1,12 @@
-import { virtualChunksGeneratorPlugin } from "./virtual-chunk-generator.js";
+import { virtualChunksGeneratorPlugins } from "./virtual-chunk-generator.js";
 import { virtualChunksResolverPlugin } from "./virtual-chunk-resolver.js";
+import type { ImportMapBuildOutput } from "./import-map-build-output.js";
 import type { Plugin } from "vite";
 import type { VitePluginImportMapsStore } from "../store.js";
 
 export function pluginImportMapsBuildEnv(
   store: VitePluginImportMapsStore,
+  buildOutput: ImportMapBuildOutput,
 ): Array<Plugin> {
   const plugins: Array<Plugin> = [];
 
@@ -12,7 +14,7 @@ export function pluginImportMapsBuildEnv(
     store.addInput(dep);
   }
 
-  plugins.push(virtualChunksGeneratorPlugin(store));
+  plugins.push(...virtualChunksGeneratorPlugins(store, buildOutput));
   plugins.push(virtualChunksResolverPlugin(store));
 
   return plugins;

--- a/src/build-only/build-plugin.ts
+++ b/src/build-only/build-plugin.ts
@@ -8,14 +8,12 @@ export function pluginImportMapsBuildEnv(
   store: VitePluginImportMapsStore,
   buildOutput: ImportMapBuildOutput,
 ): Array<Plugin> {
-  const plugins: Array<Plugin> = [];
-
   for (const dep of store.sharedDependencies) {
     store.addInput(dep);
   }
 
-  plugins.push(...virtualChunksGeneratorPlugins(store, buildOutput));
-  plugins.push(virtualChunksResolverPlugin(store));
-
-  return plugins;
+  return [
+    ...virtualChunksGeneratorPlugins(store, buildOutput),
+    virtualChunksResolverPlugin(store),
+  ];
 }

--- a/src/build-only/import-map-build-output.ts
+++ b/src/build-only/import-map-build-output.ts
@@ -3,52 +3,82 @@ import type { VitePluginImportMapsStore } from "../store.js";
 
 let importMapBuildOutputId = 0;
 
-export class ImportMapBuildOutput {
-  readonly htmlPlaceholder: string;
-  readonly filePlaceholder: string;
+export const importMapBuildMarkerAttribute = "data-vite-import-maps";
 
-  constructor() {
-    const id = importMapBuildOutputId++;
-    this.htmlPlaceholder = JSON.stringify({
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function finalizeHtmlImportMap(
+  source: string,
+  marker: string,
+  importMap: string,
+): string {
+  const escapedMarker = escapeRegExp(marker);
+  const script = new RegExp(
+    `(<script\\b(?=[^>]*\\b${importMapBuildMarkerAttribute}\\s*=\\s*["']${escapedMarker}["'])[^>]*>)[\\s\\S]*?(<\\/script\\s*>)`,
+    "gi",
+  );
+  const markerAttribute = new RegExp(
+    `\\s+${importMapBuildMarkerAttribute}\\s*=\\s*["']${escapedMarker}["']`,
+    "i",
+  );
+
+  return source.replace(
+    script,
+    (_, openingTag: string, closingTag: string) =>
+      `${openingTag.replace(markerAttribute, "")}${importMap}${closingTag}`,
+  );
+}
+
+export class ImportMapBuildOutput {
+  readonly marker: string;
+  readonly placeholder: string;
+
+  constructor(private readonly fileName?: string) {
+    this.marker = `vite-import-maps-${importMapBuildOutputId++}`;
+    this.placeholder = JSON.stringify({
       imports: {},
-      __vite_import_maps_placeholder__: `${id}:html`,
-    });
-    this.filePlaceholder = JSON.stringify({
-      imports: {},
-      __vite_import_maps_placeholder__: `${id}:file`,
+      __vite_import_maps_placeholder__: this.marker,
     });
   }
 
   finalize(bundle: OutputBundle, store: VitePluginImportMapsStore): void {
-    let importMap:
-      | ReturnType<VitePluginImportMapsStore["getImportMapAsJson"]>
-      | undefined;
+    const htmlOutputs = Object.values(bundle).filter(
+      (output) =>
+        output.type === "asset" &&
+        output.fileName.endsWith(".html") &&
+        typeof output.source === "string" &&
+        output.source.includes(this.marker),
+    );
+    const fileOutput = this.fileName ? bundle[this.fileName] : undefined;
 
-    const getImportMap = (): ReturnType<
-      VitePluginImportMapsStore["getImportMapAsJson"]
-    > => {
-      importMap ??= store.getImportMapAsJson();
-      return importMap;
-    };
+    if (htmlOutputs.length === 0 && fileOutput?.type !== "asset") {
+      return;
+    }
 
-    for (const output of Object.values(bundle)) {
-      if (output.type !== "asset" || typeof output.source !== "string") {
-        continue;
+    const importMap = store.getImportMapAsJson();
+    const compactImportMap = JSON.stringify(importMap);
+
+    for (const output of htmlOutputs) {
+      const source = output.source as string;
+      const finalized = finalizeHtmlImportMap(
+        source,
+        this.marker,
+        compactImportMap,
+      );
+
+      if (finalized === source) {
+        throw new Error(
+          `Unable to finalize the import map in ${output.fileName}`,
+        );
       }
 
-      let source = output.source;
+      output.source = finalized;
+    }
 
-      if (source.includes(this.htmlPlaceholder)) {
-        const serializedImportMap = JSON.stringify(getImportMap());
-        source = source.split(this.htmlPlaceholder).join(serializedImportMap);
-      }
-
-      if (source.includes(this.filePlaceholder)) {
-        const serializedImportMap = JSON.stringify(getImportMap(), null, 2);
-        source = source.split(this.filePlaceholder).join(serializedImportMap);
-      }
-
-      output.source = source;
+    if (fileOutput?.type === "asset") {
+      fileOutput.source = JSON.stringify(importMap, null, 2);
     }
   }
 }

--- a/src/build-only/import-map-build-output.ts
+++ b/src/build-only/import-map-build-output.ts
@@ -3,82 +3,36 @@ import type { VitePluginImportMapsStore } from "../store.js";
 
 let importMapBuildOutputId = 0;
 
-export const importMapBuildMarkerAttribute = "data-vite-import-maps";
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function finalizeHtmlImportMap(
-  source: string,
-  marker: string,
-  importMap: string,
-): string {
-  const escapedMarker = escapeRegExp(marker);
-  const script = new RegExp(
-    `(<script\\b(?=[^>]*\\b${importMapBuildMarkerAttribute}\\s*=\\s*["']${escapedMarker}["'])[^>]*>)[\\s\\S]*?(<\\/script\\s*>)`,
-    "gi",
-  );
-  const markerAttribute = new RegExp(
-    `\\s+${importMapBuildMarkerAttribute}\\s*=\\s*["']${escapedMarker}["']`,
-    "i",
-  );
-
-  return source.replace(
-    script,
-    (_, openingTag: string, closingTag: string) =>
-      `${openingTag.replace(markerAttribute, "")}${importMap}${closingTag}`,
-  );
-}
-
 export class ImportMapBuildOutput {
-  readonly marker: string;
   readonly placeholder: string;
 
-  constructor(private readonly fileName?: string) {
-    this.marker = `vite-import-maps-${importMapBuildOutputId++}`;
-    this.placeholder = JSON.stringify({
-      imports: {},
-      __vite_import_maps_placeholder__: this.marker,
-    });
+  constructor() {
+    this.placeholder = JSON.stringify(
+      `vite-import-maps-${importMapBuildOutputId++}-placeholder`,
+    );
   }
 
   finalize(bundle: OutputBundle, store: VitePluginImportMapsStore): void {
-    const htmlOutputs = Object.values(bundle).filter(
+    const outputs = Object.values(bundle).filter(
       (output) =>
         output.type === "asset" &&
-        output.fileName.endsWith(".html") &&
         typeof output.source === "string" &&
-        output.source.includes(this.marker),
+        output.source.includes(this.placeholder),
     );
-    const fileOutput = this.fileName ? bundle[this.fileName] : undefined;
 
-    if (htmlOutputs.length === 0 && fileOutput?.type !== "asset") {
-      return;
-    }
+    if (outputs.length === 0) return;
 
     const importMap = store.getImportMapAsJson();
     const compactImportMap = JSON.stringify(importMap);
+    const formattedImportMap = JSON.stringify(importMap, null, 2);
 
-    for (const output of htmlOutputs) {
+    for (const output of outputs) {
       const source = output.source as string;
-      const finalized = finalizeHtmlImportMap(
-        source,
-        this.marker,
-        compactImportMap,
-      );
-
-      if (finalized === source) {
-        throw new Error(
-          `Unable to finalize the import map in ${output.fileName}`,
-        );
-      }
-
-      output.source = finalized;
-    }
-
-    if (fileOutput?.type === "asset") {
-      fileOutput.source = JSON.stringify(importMap, null, 2);
+      const serializedImportMap =
+        source.trim() === this.placeholder
+          ? formattedImportMap
+          : compactImportMap;
+      output.source = source.replaceAll(this.placeholder, serializedImportMap);
     }
   }
 }

--- a/src/build-only/import-map-build-output.ts
+++ b/src/build-only/import-map-build-output.ts
@@ -1,0 +1,54 @@
+import type { OutputBundle } from "rolldown";
+import type { VitePluginImportMapsStore } from "../store.js";
+
+let importMapBuildOutputId = 0;
+
+export class ImportMapBuildOutput {
+  readonly htmlPlaceholder: string;
+  readonly filePlaceholder: string;
+
+  constructor() {
+    const id = importMapBuildOutputId++;
+    this.htmlPlaceholder = JSON.stringify({
+      imports: {},
+      __vite_import_maps_placeholder__: `${id}:html`,
+    });
+    this.filePlaceholder = JSON.stringify({
+      imports: {},
+      __vite_import_maps_placeholder__: `${id}:file`,
+    });
+  }
+
+  finalize(bundle: OutputBundle, store: VitePluginImportMapsStore): void {
+    let importMap:
+      | ReturnType<VitePluginImportMapsStore["getImportMapAsJson"]>
+      | undefined;
+
+    const getImportMap = (): ReturnType<
+      VitePluginImportMapsStore["getImportMapAsJson"]
+    > => {
+      importMap ??= store.getImportMapAsJson();
+      return importMap;
+    };
+
+    for (const output of Object.values(bundle)) {
+      if (output.type !== "asset" || typeof output.source !== "string") {
+        continue;
+      }
+
+      let source = output.source;
+
+      if (source.includes(this.htmlPlaceholder)) {
+        const serializedImportMap = JSON.stringify(getImportMap());
+        source = source.split(this.htmlPlaceholder).join(serializedImportMap);
+      }
+
+      if (source.includes(this.filePlaceholder)) {
+        const serializedImportMap = JSON.stringify(getImportMap(), null, 2);
+        source = source.split(this.filePlaceholder).join(serializedImportMap);
+      }
+
+      output.source = source;
+    }
+  }
+}

--- a/src/build-only/virtual-chunk-generator.ts
+++ b/src/build-only/virtual-chunk-generator.ts
@@ -4,85 +4,35 @@ import { styleText } from "node:util";
 import { createLogger } from "vite";
 import { pluginName } from "../config.js";
 import { isAbsolute, normalizePath } from "../utils.js";
-import {
-  VIRTUAL_ID_PREFIX,
-  getVirtualFileName,
-} from "./virtual-chunk-resolver.js";
+import { getVirtualFileName } from "./virtual-chunk-resolver.js";
 import type { ImportMapBuildOutput } from "./import-map-build-output.js";
 import type {
   ImportMapBuildChunkEntrypoint,
   VitePluginImportMapsStore,
 } from "../store.js";
 import type { Plugin } from "vite";
-import type { OutputBundle, OutputChunk } from "rolldown";
+
+function calculateIntegrity(
+  integrityConfig: ImportMapBuildChunkEntrypoint["integrity"],
+  code: string,
+): string | undefined {
+  if (integrityConfig === false) return;
+
+  const algorithm =
+    typeof integrityConfig === "string" ? integrityConfig : "sha384";
+  return `${algorithm}-${createHash(algorithm).update(code).digest("base64")}`;
+}
 
 export function virtualChunksGeneratorPlugins(
   store: VitePluginImportMapsStore,
   buildOutput: ImportMapBuildOutput,
 ): Array<Plugin> {
   const name = pluginName("build:virtual");
-  const virtualModules = new Map<string, ImportMapBuildChunkEntrypoint>();
-  const localModules = new Map<string, ImportMapBuildChunkEntrypoint>();
+  const modules = new Map<string, Array<ImportMapBuildChunkEntrypoint>>();
   const logger = createLogger(undefined, {
     prefix: name,
   });
   let root = process.cwd();
-
-  function findImportMapEntrypoint(
-    facadeModuleId: string | null,
-  ): ImportMapBuildChunkEntrypoint | undefined {
-    if (
-      !facadeModuleId ||
-      (!facadeModuleId.startsWith(VIRTUAL_ID_PREFIX) &&
-        !isAbsolute(facadeModuleId))
-    ) {
-      return;
-    }
-
-    const normalizedFacadeModuleId = normalizePath(facadeModuleId);
-    return (
-      virtualModules.get(normalizedFacadeModuleId) ??
-      localModules.get(normalizedFacadeModuleId)
-    );
-  }
-
-  function forEachImportMapChunk(
-    bundle: OutputBundle,
-    callback: (
-      entry: OutputChunk,
-      entryImportMap: ImportMapBuildChunkEntrypoint,
-    ) => void,
-  ): void {
-    for (const entry of Object.values(bundle)) {
-      if (entry.type !== "chunk") continue;
-
-      const entryImportMap = findImportMapEntrypoint(entry.facadeModuleId);
-      if (!entryImportMap) continue;
-
-      callback(entry, entryImportMap);
-    }
-  }
-
-  function collectDependencies(bundle: OutputBundle): void {
-    store.clearDependencies();
-
-    forEachImportMapChunk(bundle, (entry, entryImportMap) => {
-      let integrity: string | undefined;
-      if (entryImportMap.integrity !== false) {
-        const algorithm =
-          typeof entryImportMap.integrity === "string"
-            ? entryImportMap.integrity
-            : "sha384";
-        integrity = `${algorithm}-${createHash(algorithm)
-          .update(entry.code)
-          .digest("base64")}`;
-      }
-
-      const url = `./${entry.fileName}`;
-      const packageName = entryImportMap.originalDependencyName;
-      store.addDependency({ url, packageName, integrity });
-    });
-  }
 
   const generator: Plugin = {
     name,
@@ -92,49 +42,35 @@ export function virtualChunksGeneratorPlugins(
     },
     buildStart() {
       logger.info("Emit chunks for exposed dependencies", { timestamp: true });
+      modules.clear();
+
       for (const input of store.inputs) {
-        if (input.localFile) {
-          // a local file doesn't have to be handled like a virtual
-          // since I expect their source is already correct and doesn't
-          // need to be transformed
-          const id = isAbsolute(input.idToResolve)
+        const id = input.localFile
+          ? isAbsolute(input.idToResolve)
             ? normalizePath(input.idToResolve)
-            : normalizePath(path.resolve(root, input.idToResolve));
-          if (!localModules.has(id)) {
-            if (store.log) {
-              console.info(
-                `   ${styleText("cyanBright", `${input.normalizedDependencyName}:`)} %s`,
-                id,
-              );
-            }
+            : normalizePath(path.resolve(root, input.idToResolve))
+          : getVirtualFileName(input.normalizedDependencyName);
+        const registeredInputs = modules.get(id);
 
-            this.emitFile({
-              type: "chunk",
-              name: input.entrypoint,
-              id,
-              preserveSignature: "strict",
-            });
-          }
-          localModules.set(id, input);
-        } else {
-          const id = getVirtualFileName(input.normalizedDependencyName);
-          if (!virtualModules.has(id)) {
-            if (store.log) {
-              console.info(
-                `   ${styleText("cyanBright", `${input.normalizedDependencyName}`)} %s`,
-                id,
-              );
-            }
-
-            this.emitFile({
-              type: "chunk",
-              name: input.entrypoint,
-              id,
-              preserveSignature: "strict",
-            });
-          }
-          virtualModules.set(id, input);
+        if (registeredInputs) {
+          registeredInputs.push(input);
+          continue;
         }
+
+        modules.set(id, [input]);
+        if (store.log) {
+          console.info(
+            `   ${styleText("cyanBright", `${input.normalizedDependencyName}:`)} %s`,
+            id,
+          );
+        }
+
+        this.emitFile({
+          type: "chunk",
+          name: input.entrypoint,
+          id,
+          preserveSignature: "strict",
+        });
       }
     },
     generateBundle(_, bundle) {
@@ -142,10 +78,14 @@ export function virtualChunksGeneratorPlugins(
         timestamp: true,
       });
 
-      forEachImportMapChunk(bundle, (entry) => {
+      for (const output of Object.values(bundle)) {
+        if (output.type !== "chunk" || !output.facadeModuleId) continue;
+        const inputs = modules.get(normalizePath(output.facadeModuleId));
+        if (!inputs) continue;
+
         // TODO: https://vite.dev/guide/backend-integration
-        entry.isEntry = false;
-      });
+        output.isEntry = false;
+      }
     },
   };
 
@@ -157,7 +97,21 @@ export function virtualChunksGeneratorPlugins(
       handler(_, bundle) {
         // Vite can still rewrite dynamic-import preload dependencies in its
         // normal generateBundle hooks, so integrity must be calculated here.
-        collectDependencies(bundle);
+        store.clearDependencies();
+
+        for (const output of Object.values(bundle)) {
+          if (output.type !== "chunk" || !output.facadeModuleId) continue;
+          const inputs = modules.get(normalizePath(output.facadeModuleId));
+          if (!inputs) continue;
+
+          for (const input of inputs) {
+            store.addDependency({
+              packageName: input.originalDependencyName,
+              url: `./${output.fileName}`,
+              integrity: calculateIntegrity(input.integrity, output.code),
+            });
+          }
+        }
 
         if (store.log) {
           store.importMapDependencies.forEach((value, key) => {

--- a/src/build-only/virtual-chunk-generator.ts
+++ b/src/build-only/virtual-chunk-generator.ts
@@ -8,15 +8,18 @@ import {
   VIRTUAL_ID_PREFIX,
   getVirtualFileName,
 } from "./virtual-chunk-resolver.js";
+import type { ImportMapBuildOutput } from "./import-map-build-output.js";
 import type {
   ImportMapBuildChunkEntrypoint,
   VitePluginImportMapsStore,
 } from "../store.js";
 import type { Plugin } from "vite";
+import type { OutputBundle, OutputChunk } from "rolldown";
 
-export function virtualChunksGeneratorPlugin(
+export function virtualChunksGeneratorPlugins(
   store: VitePluginImportMapsStore,
-): Plugin {
+  buildOutput: ImportMapBuildOutput,
+): Array<Plugin> {
   const name = pluginName("build:virtual");
   const virtualModules = new Map<string, ImportMapBuildChunkEntrypoint>();
   const localModules = new Map<string, ImportMapBuildChunkEntrypoint>();
@@ -25,7 +28,63 @@ export function virtualChunksGeneratorPlugin(
   });
   let root = process.cwd();
 
-  return {
+  function findImportMapEntrypoint(
+    facadeModuleId: string | null,
+  ): ImportMapBuildChunkEntrypoint | undefined {
+    if (
+      !facadeModuleId ||
+      (!facadeModuleId.startsWith(VIRTUAL_ID_PREFIX) &&
+        !isAbsolute(facadeModuleId))
+    ) {
+      return;
+    }
+
+    const normalizedFacadeModuleId = normalizePath(facadeModuleId);
+    return (
+      virtualModules.get(normalizedFacadeModuleId) ??
+      localModules.get(normalizedFacadeModuleId)
+    );
+  }
+
+  function forEachImportMapChunk(
+    bundle: OutputBundle,
+    callback: (
+      entry: OutputChunk,
+      entryImportMap: ImportMapBuildChunkEntrypoint,
+    ) => void,
+  ): void {
+    for (const entry of Object.values(bundle)) {
+      if (entry.type !== "chunk") continue;
+
+      const entryImportMap = findImportMapEntrypoint(entry.facadeModuleId);
+      if (!entryImportMap) continue;
+
+      callback(entry, entryImportMap);
+    }
+  }
+
+  function collectDependencies(bundle: OutputBundle): void {
+    store.clearDependencies();
+
+    forEachImportMapChunk(bundle, (entry, entryImportMap) => {
+      let integrity: string | undefined;
+      if (entryImportMap.integrity !== false) {
+        const algorithm =
+          typeof entryImportMap.integrity === "string"
+            ? entryImportMap.integrity
+            : "sha384";
+        integrity = `${algorithm}-${createHash(algorithm)
+          .update(entry.code)
+          .digest("base64")}`;
+      }
+
+      const url = `./${entry.fileName}`;
+      const packageName = entryImportMap.originalDependencyName;
+      store.addDependency({ url, packageName, integrity });
+    });
+  }
+
+  const generator: Plugin = {
     name,
     apply: "build",
     configResolved(config) {
@@ -78,61 +137,41 @@ export function virtualChunksGeneratorPlugin(
         }
       }
     },
-    // We'll get here the final name of the generated chunk
-    // to track the import-maps dependencies
     generateBundle(_, bundle) {
-      store.clearDependencies();
-      logger.info("Collect dependencies and generate import map", {
+      logger.info("Prepare chunks for import map", {
         timestamp: true,
       });
 
-      const keys = Object.keys(bundle);
-      for (const key of keys) {
-        const entry = bundle[key];
-        if (entry.type !== "chunk") continue;
-
-        const handledModules = new Map([
-          ...virtualModules.entries(),
-          ...localModules.entries(),
-        ]);
-
-        if (
-          entry.facadeModuleId &&
-          (entry.facadeModuleId.startsWith(VIRTUAL_ID_PREFIX) ||
-            isAbsolute(entry.facadeModuleId))
-        ) {
-          const facadeModuleId = normalizePath(entry.facadeModuleId);
-          const entryImportMap = handledModules.get(facadeModuleId);
-          if (!entryImportMap) continue;
-
-          // TODO: https://vite.dev/guide/backend-integration
-          entry.isEntry = false;
-
-          let integrity: string | undefined;
-          if (entryImportMap.integrity !== false) {
-            const algorithm =
-              typeof entryImportMap.integrity === "string"
-                ? entryImportMap.integrity
-                : "sha384";
-            integrity = `${algorithm}-${createHash(algorithm)
-              .update(entry.code)
-              .digest("base64")}`;
-          }
-
-          const url = `./${entry.fileName}`,
-            packageName = entryImportMap.originalDependencyName;
-          store.addDependency({ url, packageName, integrity });
-        }
-      }
-
-      if (store.log) {
-        store.importMapDependencies.forEach((value, key) => {
-          console.info(
-            `   ${styleText("cyanBright", `${key}:`)} %s`,
-            value.url,
-          );
-        });
-      }
+      forEachImportMapChunk(bundle, (entry) => {
+        // TODO: https://vite.dev/guide/backend-integration
+        entry.isEntry = false;
+      });
     },
   };
+
+  const finalizer: Plugin = {
+    name: pluginName("build:finalize"),
+    apply: "build",
+    generateBundle: {
+      order: "post",
+      handler(_, bundle) {
+        // Vite can still rewrite dynamic-import preload dependencies in its
+        // normal generateBundle hooks, so integrity must be calculated here.
+        collectDependencies(bundle);
+
+        if (store.log) {
+          store.importMapDependencies.forEach((value, key) => {
+            console.info(
+              `   ${styleText("cyanBright", `${key}:`)} %s`,
+              value.url,
+            );
+          });
+        }
+
+        buildOutput.finalize(bundle, store);
+      },
+    },
+  };
+
+  return [generator, finalizer];
 }

--- a/src/import-map-file.ts
+++ b/src/import-map-file.ts
@@ -30,7 +30,7 @@ export function pluginImportMapsAsFile(
       this.emitFile({
         type: "asset",
         fileName: `${name}.json`,
-        source: buildOutput.filePlaceholder,
+        source: buildOutput.placeholder,
       });
     },
   };

--- a/src/import-map-file.ts
+++ b/src/import-map-file.ts
@@ -1,4 +1,5 @@
 import { pluginName } from "./config.js";
+import type { ImportMapBuildOutput } from "./build-only/import-map-build-output.js";
 import type { Plugin } from "vite";
 import type { VitePluginImportMapsStore } from "./store.js";
 
@@ -9,6 +10,7 @@ interface PluginImportMapsAsFileOptions {
 export function pluginImportMapsAsFile(
   store: VitePluginImportMapsStore,
   options: PluginImportMapsAsFileOptions,
+  buildOutput: ImportMapBuildOutput,
 ): Plugin {
   const { name = "import-map" } = options;
 
@@ -25,12 +27,10 @@ export function pluginImportMapsAsFile(
       });
     },
     generateBundle() {
-      const json = store.getImportMapAsJson();
-
       this.emitFile({
         type: "asset",
         fileName: `${name}.json`,
-        source: JSON.stringify(json, null, 2),
+        source: buildOutput.filePlaceholder,
       });
     },
   };

--- a/src/import-map-html.ts
+++ b/src/import-map-html.ts
@@ -1,4 +1,5 @@
 import { pluginName } from "./config.js";
+import { importMapBuildMarkerAttribute } from "./build-only/import-map-build-output.js";
 import type { ImportMapBuildOutput } from "./build-only/import-map-build-output.js";
 import type { Plugin } from "vite";
 import type { VitePluginImportMapsStore } from "./store.js";
@@ -10,19 +11,25 @@ export function pluginImportMapsInject(
   const name = pluginName("inject-html-import-map");
   return {
     name,
-    transformIndexHtml(source, { server }) {
+    transformIndexHtml(source, { bundle }) {
       // Development has no generated chunks to hash. Build output is filled
       // after Vite finishes rewriting chunks in generateBundle.
-      const importMap = server
-        ? JSON.stringify(store.getImportMapAsJson())
-        : buildOutput.htmlPlaceholder;
+      const isBuild = bundle !== undefined;
+      const importMap = isBuild
+        ? buildOutput.placeholder
+        : JSON.stringify(store.getImportMapAsJson());
+      const attrs: Record<string, string> = { type: "importmap" };
+
+      if (isBuild) {
+        attrs[importMapBuildMarkerAttribute] = buildOutput.marker;
+      }
 
       return {
         html: source,
         tags: [
           {
             tag: "script",
-            attrs: { type: "importmap" },
+            attrs,
             children: importMap,
             injectTo: "head-prepend",
           },

--- a/src/import-map-html.ts
+++ b/src/import-map-html.ts
@@ -1,15 +1,21 @@
 import { pluginName } from "./config.js";
+import type { ImportMapBuildOutput } from "./build-only/import-map-build-output.js";
 import type { Plugin } from "vite";
 import type { VitePluginImportMapsStore } from "./store.js";
 
 export function pluginImportMapsInject(
   store: VitePluginImportMapsStore,
+  buildOutput: ImportMapBuildOutput,
 ): Plugin {
   const name = pluginName("inject-html-import-map");
   return {
     name,
-    transformIndexHtml(source) {
-      const importMap = store.getImportMapAsJson();
+    transformIndexHtml(source, { server }) {
+      // Development has no generated chunks to hash. Build output is filled
+      // after Vite finishes rewriting chunks in generateBundle.
+      const importMap = server
+        ? JSON.stringify(store.getImportMapAsJson())
+        : buildOutput.htmlPlaceholder;
 
       return {
         html: source,
@@ -17,7 +23,7 @@ export function pluginImportMapsInject(
           {
             tag: "script",
             attrs: { type: "importmap" },
-            children: JSON.stringify(importMap),
+            children: importMap,
             injectTo: "head-prepend",
           },
         ],

--- a/src/import-map-html.ts
+++ b/src/import-map-html.ts
@@ -1,5 +1,4 @@
 import { pluginName } from "./config.js";
-import { importMapBuildMarkerAttribute } from "./build-only/import-map-build-output.js";
 import type { ImportMapBuildOutput } from "./build-only/import-map-build-output.js";
 import type { Plugin } from "vite";
 import type { VitePluginImportMapsStore } from "./store.js";
@@ -18,18 +17,13 @@ export function pluginImportMapsInject(
       const importMap = isBuild
         ? buildOutput.placeholder
         : JSON.stringify(store.getImportMapAsJson());
-      const attrs: Record<string, string> = { type: "importmap" };
-
-      if (isBuild) {
-        attrs[importMapBuildMarkerAttribute] = buildOutput.marker;
-      }
 
       return {
         html: source,
         tags: [
           {
             tag: "script",
-            attrs,
+            attrs: { type: "importmap" },
             children: importMap,
             injectTo: "head-prepend",
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,10 @@ export function viteImportMaps(
   const plugins: Array<Plugin> = [];
 
   const store = new VitePluginImportMapsStore(options);
-  const buildOutput = new ImportMapBuildOutput();
+  const outputFileName = outputAsFile
+    ? `${typeof outputAsFile === "string" ? outputAsFile : "import-map"}.json`
+    : undefined;
+  const buildOutput = new ImportMapBuildOutput(outputFileName);
 
   plugins.push(...pluginImportMapsBuildEnv(store, buildOutput));
   plugins.push(pluginImportMapsDevelopmentEnv(store));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { VitePluginImportMapsStore } from "./store.js";
 import { pluginImportMapsBuildEnv } from "./build-only/build-plugin.js";
+import { ImportMapBuildOutput } from "./build-only/import-map-build-output.js";
 import { pluginImportMapsInject } from "./import-map-html.js";
 import { pluginImportMapsDevelopmentEnv } from "./dev/dev-plugin.js";
 import { pluginImportMapsAsFile } from "./import-map-file.js";
@@ -15,19 +16,20 @@ export function viteImportMaps(
   const plugins: Array<Plugin> = [];
 
   const store = new VitePluginImportMapsStore(options);
+  const buildOutput = new ImportMapBuildOutput();
 
-  plugins.push(...pluginImportMapsBuildEnv(store));
+  plugins.push(...pluginImportMapsBuildEnv(store, buildOutput));
   plugins.push(pluginImportMapsDevelopmentEnv(store));
 
   if (injectImportMapsToHtml) {
-    plugins.push(pluginImportMapsInject(store));
+    plugins.push(pluginImportMapsInject(store, buildOutput));
   }
 
   plugins.push(pluginImportMapsAsModule(store));
 
   if (outputAsFile) {
     const name = typeof outputAsFile === "string" ? outputAsFile : undefined;
-    plugins.push(pluginImportMapsAsFile(store, { name }));
+    plugins.push(pluginImportMapsAsFile(store, { name }, buildOutput));
   }
 
   return plugins;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,7 @@ export function viteImportMaps(
   const plugins: Array<Plugin> = [];
 
   const store = new VitePluginImportMapsStore(options);
-  const outputFileName = outputAsFile
-    ? `${typeof outputAsFile === "string" ? outputAsFile : "import-map"}.json`
-    : undefined;
-  const buildOutput = new ImportMapBuildOutput(outputFileName);
+  const buildOutput = new ImportMapBuildOutput();
 
   plugins.push(...pluginImportMapsBuildEnv(store, buildOutput));
   plugins.push(pluginImportMapsDevelopmentEnv(store));


### PR DESCRIPTION
## Summary
- Calculate import-map integrity hashes from final emitted chunk contents.
- Defer HTML and JSON import-map generation until bundle finalization.
- Add regression coverage for emitted and in-memory builds, including development injection.

## Testing
- Added integration tests covering GH-29 for written and in-memory build outputs.
- Extended development import-map plugin coverage.